### PR TITLE
CI: use requirements-dev.txt to limit hardcoding in actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pylint diff_cover
+          pip install -r requirements-dev.txt
 
       - name: Pylint
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# necessary dev/test tasks
+pylint
+diff_cover


### PR DESCRIPTION
This small cleanup comes from the draft `tests` branch, and is useful in both `tests` and `py3` branches