### PR TITLE
xcp/cpiofile.py: covert German umlauts in comments to UTF-8, enables pytype on it

### DIFF
--- a/run-pytype.py
+++ b/run-pytype.py
@@ -115,6 +115,7 @@ def main(me: str, branch_url: str):
     )
     excludes = [
         "xcp/cmd.py",
+        "xcp/cpiofile.py",
         "xcp/net/ip.py",
         "xcp/net/biosdevname.py",
     ]

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
-# -*- coding: iso-8859-1 -*-
+# -*- coding: utf-8 -*-
 #-------------------------------------------------------------------
 # cpiofile.py
 #-------------------------------------------------------------------
 
-# Copyright (C) 2002 Lars Gust‰bel <lars@gustaebel.de>
+# Copyright (C) 2002 Lars Gust√§bel <lars@gustaebel.de>
 # Copyright (c) 2013, Citrix Inc.
 # All rights reserved.
 #
@@ -31,13 +31,13 @@
 
 """Read from and write to cpio format archives.
 
-   Derived from Lars Gust‰bel's tarfile.py
+   Derived from Lars Gust√§bel's tarfile.py
 """
 from __future__ import print_function
 
 __version__ = "0.1"
 __author__  = "Simon Rowe"
-__credits__ = "Lars Gust‰bel, Gustavo Niemeyer, Niels Gust‰bel, Richard Townsend."
+__credits__ = "Lars Gust√§bel, Gustavo Niemeyer, Niels Gust√§bel, Richard Townsend."
 
 #---------
 # Imports


### PR DESCRIPTION
[xcp/cpiofile.py: convert to UTF-8, enables pytype checker for it](https://github.com/xenserver/python-libs/commit/f2317ce8aec3aec4e0f7ede556e9c3740bc699c3)!

Because of the conversion of it to to UTF-8, there is a one major effect:

* The pytype checker now checks the file and emits many errors (at least some are real).
    * Make these errors non-fatal for CI for now. (to be fixed in upcoming PRs)

Note: The errors are still shown on the GitHub Action Summary page
and on stdout during local CI.
