### PR TITLE
.github/workflows/main.yml: CodeCov: Upload coverage for py27/38 with separate flags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,13 +70,22 @@ jobs:
         if: ${{ matrix.python-version == 2.7 }}
         run: tox --workdir .github/workflows/.tox --recreate -e py38-covcombine
 
-      - name: Upload coverage reports to Codecov
+      - name: Upload the Python 2.7 coverage report to Codecov
+        if: ${{ matrix.python-version == 2.7 }}
+        uses: codecov/codecov-action@v3
+        with:
+          directory: .github/workflows/.tox/py27-cov/log
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+          flags: Python-2.7
+          verbose: true
+
+      - name: Upload the Python 3.8 coverage report to Codecov
         if: ${{ matrix.python-version == 2.7 }}
         uses: codecov/codecov-action@v3
         with:
           directory: .github/workflows/.tox/py38-covcombine/log
           env_vars: OS,PYTHON
           fail_ci_if_error: true
-          flags: unittest
-          name: py27-py38-combined
+          flags: Python-3.8
           verbose: true

--- a/tox.ini
+++ b/tox.ini
@@ -106,12 +106,12 @@ commands    =
                      {envlogdir}/coverage.xml
 
 [covcombine]
-description = Generate combined coverage reports with py27-test coverage merged
+description = Generate combined coverage reports with py27-cov coverage merged
 commands =
-    tox -e py27-test
+    tox -e py27-cov
     sh -c 'export COVERAGE_FILE=$COVERAGE_FILE-combined; \
-    coverage combine --keep {envlogdir}/../../py27-test/log/.coverage {envlogdir}/.coverage;\
-    coverage xml  -o {envlogdir}/coverage.xml;\
+    coverage combine --keep {envlogdir}/../../py27-cov/log/.coverage {envlogdir}/.coverage;\
+    coverage xml  -o {envlogdir}/coverage-combined.xml;\
     coverage html -d {envlogdir}/htmlcov;\
     coverage html -d {envlogdir}/htmlcov-tests --include="tests/*"'
     sh -c '\
@@ -119,11 +119,11 @@ commands =
       --ignore-whitespace --show-uncovered --fail-under {env:DIFF_COVCOMBINE_MIN:100} \
       --html-report     {envlogdir}/coverage-diff.html                                \
       --markdown-report {envlogdir}/coverage-diff.md                                  \
-                        {envlogdir}/coverage.xml;      EXIT_CODE=$?;echo $EXIT_CODE;  \
+                        {envlogdir}/coverage-combined.xml; EXITCODE=$?;echo $EXITCODE;\
     GITHUB_STEP_SUMMARY={env:GITHUB_STEP_SUMMARY:.git/GITHUB_STEP_SUMMARY.md};        \
            if     [ -n "$GITHUB_STEP_SUMMARY" ];  then      sed "/title/,/\/style/d"  \
                         {envlogdir}/coverage-diff.html  >>"$GITHUB_STEP_SUMMARY"; fi; \
-    exit $EXIT_CODE'
+    exit $EXITCODE'
 
 [lint]
 description = Run pylint and fail on warnings remaining on lines in the diff to master


### PR DESCRIPTION
One TODO @pau gave me was to eventually upload coverage for py27 and py38 separately.

This does it, and does not change code.

Codecov likes to say that "indirect code coverage" was reduced, which is a bug in CodeCov.