### PR TITLE
cmd: Support Python3.6+: Add support for Py3 Popen() and open() APIs

### DIFF
--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -130,6 +130,14 @@ class TestCache(unittest.TestCase):
         return_values = runCmd("cat >&2", False, True, inputtext=stdin)
         self.assertEqual(return_values, (0, stdin))
 
+    def test_runCmd_tee_unicode_outerr(self):
+        stdin = "✋➔Hello World(🗺)‼"
+        for _ in [1, 2]:  # 1st for running, 2nd for using the cache
+            return_values = self.c.runCmd(
+                "bash -c 'tee /dev/stderr'", True, True, inputtext=stdin
+            )
+            self.assertEqual(return_values, (0, stdin, stdin))
+
     def test_runCmd_cat_unicode_stdout(self):
         stdin = "✋➔Hello 🔛 stdout ✅ World(🗺)‼"
         for _ in [1, 2]:  # 1st for running, 2nd for using the cache

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -13,6 +13,7 @@ class TestCache(unittest.TestCase):
         expected_kwargs = kwargs.pop("expected_kwargs", {})
         with patch("xcp.cmd.open", mock_open(read_data=read_data)) as open_mock:
             # uncached fileContents
+            self.c.clearCache()
             data = self.c.fileContents("/tmp/foo", *args, **kwargs)
             open_mock.assert_called_once_with("/tmp/foo", *args, **expected_kwargs)
             self.assertEqual(data, read_data)
@@ -34,6 +35,12 @@ class TestCache(unittest.TestCase):
         expected = open_utf8.copy()
         expected["mode"] = "t"
         self.check_fileContents("line1\nline2\n", mode="t", expected_kwargs=expected)
+
+    def test_fileContents_mock_binary(self):
+        self.check_fileContents(b"line1\nline2\n", "b")
+
+    def test_fileContents_mock_mode_b(self):
+        self.check_fileContents(b"line1\nline2\n", mode="b", expected_kwargs={"mode": "b"})
 
     def test_runCmd(self):
         output_data = "line1\nline2\n"

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -3,16 +3,18 @@ import unittest
 from mock import patch, Mock, DEFAULT, mock_open
 
 from xcp.cmd import OutputCache
+from xcp.compat import open_utf8
 
 class TestCache(unittest.TestCase):
     def setUp(self):
         self.c = OutputCache()
 
-    def check_fileContents(self, read_data):
+    def check_fileContents(self, read_data, *args, **kwargs):
+        expected_kwargs = kwargs.pop("expected_kwargs", {})
         with patch("xcp.cmd.open", mock_open(read_data=read_data)) as open_mock:
             # uncached fileContents
             data = self.c.fileContents('/tmp/foo')
-            open_mock.assert_called_once_with("/tmp/foo")
+            open_mock.assert_called_once_with("/tmp/foo", *args, **expected_kwargs)
             self.assertEqual(data, read_data)
 
             # rerun as cached
@@ -25,11 +27,11 @@ class TestCache(unittest.TestCase):
             open_mock.reset_mock()
             self.c.clearCache()
             data = self.c.fileContents('/tmp/foo')
-            open_mock.assert_called_once_with("/tmp/foo")
+            open_mock.assert_called_once_with("/tmp/foo", *args, **expected_kwargs)
             self.assertEqual(data, read_data)
 
     def test_fileContents_mock_string(self):
-        self.check_fileContents("line1\nline2\n")
+        self.check_fileContents("line1\nline2\n", expected_kwargs=open_utf8)
 
     def test_runCmd(self):
         output_data = "line1\nline2\n"

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -13,25 +13,27 @@ class TestCache(unittest.TestCase):
         expected_kwargs = kwargs.pop("expected_kwargs", {})
         with patch("xcp.cmd.open", mock_open(read_data=read_data)) as open_mock:
             # uncached fileContents
-            data = self.c.fileContents('/tmp/foo')
+            data = self.c.fileContents("/tmp/foo", *args, **kwargs)
             open_mock.assert_called_once_with("/tmp/foo", *args, **expected_kwargs)
             self.assertEqual(data, read_data)
 
             # rerun as cached
             open_mock.reset_mock()
-            data = self.c.fileContents('/tmp/foo')
+            data = self.c.fileContents("/tmp/foo", *args, **kwargs)
             open_mock.assert_not_called()
             self.assertEqual(data, read_data)
 
             # rerun after clearing cache
             open_mock.reset_mock()
             self.c.clearCache()
-            data = self.c.fileContents('/tmp/foo')
+            data = self.c.fileContents("/tmp/foo", *args, **kwargs)
             open_mock.assert_called_once_with("/tmp/foo", *args, **expected_kwargs)
             self.assertEqual(data, read_data)
 
     def test_fileContents_mock_string(self):
-        self.check_fileContents("line1\nline2\n", expected_kwargs=open_utf8)
+        expected = open_utf8.copy()
+        expected["mode"] = "t"
+        self.check_fileContents("line1\nline2\n", mode="t", expected_kwargs=expected)
 
     def test_runCmd(self):
         output_data = "line1\nline2\n"

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# sourcery skip: extract-duplicate-method,no-loop-in-tests
+# sourcery skip: extract-duplicate-method,no-conditionals-in-tests,no-loop-in-tests
+import sys
 import unittest
 from typing import cast, Type
 
@@ -159,3 +160,19 @@ class TestCache(unittest.TestCase):
         for _ in [1, 2]:  # rerun as cached
             return_values = self.c.runCmd("cat >&2", False, True, inputtext=stdin)
             self.assertEqual(return_values, (0, stdin))
+
+    def test_runCmd_echo_stdout_list(self):
+        text = "✋➔Hello 🔛 stdout ✅ World(🗺) with a Unicode string in the cmd list"
+        kwargs = {}
+        if sys.version_info >= (3, 0):
+            kwargs["mode"] = "t"
+        return_values = self.c.runCmd(["echo", "-n", text], with_stdout=True, **kwargs)
+        self.assertEqual(return_values, (0, text))
+
+    def test_runCmd_echo_stdout_shell(self):
+        text = "✋➔Hello 🔛 stdout ✅ World(🗺) with a Unicode string as the command"
+        kwargs = {}
+        if sys.version_info >= (3, 0):
+            kwargs["mode"] = "t"
+        return_values = self.c.runCmd("echo -n '" + text + "'", with_stdout=True, **kwargs)
+        self.assertEqual(return_values, (0, text))

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ skip_missing_interpreters = true
 description = Run pytest in this environment with --cov for use in other stages
 extras      = test
 commands    =
-    pytest --cov -v {env:PYTEST_MD_REPORT}
+    pytest --cov -v {env:PYTEST_MD_REPORT} tests/
     sh -c 'ls -l {env:COVERAGE_FILE}'
     sh -c 'if [ -n "{env:PYTEST_MD_REPORT_OUTPUT}" -a -n "{env:GITHUB_STEP_SUMMARY}" ];then    \
       sed -i "s/tests\(.*py\)/[&](&)/" {env:PYTEST_MD_REPORT_OUTPUT}; sed "/title/,/\/style/d" \

--- a/xcp/cmd.py
+++ b/xcp/cmd.py
@@ -25,7 +25,9 @@
 
 import subprocess
 
-import xcp.logger as logger
+from xcp import logger
+from xcp.compat import open_defaults_for_utf8_text
+
 
 def runCmd(command, with_stdout = False, with_stderr = False, inputtext = None):
     cmd = subprocess.Popen(command, bufsize=1,
@@ -60,11 +62,13 @@ class OutputCache(object):
     def __init__(self):
         self.cache = {}
 
-    def fileContents(self, fn):
+    def fileContents(self, fn, *args, **kwargs):
+        open_defaults_for_utf8_text(args, kwargs)
         key = 'file:' + fn
         if key not in self.cache:
             logger.debug("Opening " + fn)
-            f = open(fn)
+            # pylint: disable=unspecified-encoding
+            f = open(fn, **kwargs)
             self.cache[key] = ''.join(f.readlines())
             f.close()
         return self.cache[key]

--- a/xcp/cmd.py
+++ b/xcp/cmd.py
@@ -63,10 +63,10 @@ class OutputCache(object):
         self.cache = {}
 
     def fileContents(self, fn, *args, **kwargs):
-        mode = open_defaults_for_utf8_text(args, kwargs)
-        key = 'file:' + fn
+        mode, other_kwargs = open_defaults_for_utf8_text(args, kwargs)
+        key = "file:" + fn + "," + mode + (str(other_kwargs) if other_kwargs else "")
         if key not in self.cache:
-            logger.debug("Opening " + fn)
+            logger.debug("Opening " + key)
             # pylint: disable=unspecified-encoding
             with open(fn, *args, **kwargs) as f:
                 self.cache[key] = f.read() if "b" in mode else "".join(f.readlines())

--- a/xcp/cmd.py
+++ b/xcp/cmd.py
@@ -105,16 +105,27 @@ class OutputCache(object):
         rckey = 'cmd.rc:' + key
         outkey = 'cmd.out:' + key
         errkey = 'cmd.err:' + key
-        if rckey not in self.cache:
-            self.cache[rckey], self.cache[outkey], self.cache[errkey] = runCmd(  # pyright: ignore
-                command, True, True, inputtext, **kwargs
-            )
+        cache = self.cache
         if with_stdout and with_stderr:
+            if rckey not in cache:
+                cache[rckey], cache[outkey], cache[errkey] = runCmd(  # pyright: ignore
+                   command, True, True, inputtext, **kwargs
+                )
             return self.cache[rckey], self.cache[outkey], self.cache[errkey]
-        elif with_stdout:
+        if with_stdout:
+            if rckey not in cache:
+                cache[rckey], cache[outkey] = runCmd(  # pyright: ignore
+                   command, True, False, inputtext, **kwargs
+                )
             return self.cache[rckey], self.cache[outkey]
-        elif with_stderr:
+        if with_stderr:
+            if rckey not in cache:
+                cache[rckey], cache[errkey] = runCmd(  # pyright: ignore
+                   command, False, True, inputtext, **kwargs
+                )
             return self.cache[rckey], self.cache[errkey]
+        if rckey not in cache:
+            cache[rckey] = runCmd(command, False, False, inputtext, **kwargs)
         return self.cache[rckey]
 
     def clearCache(self):

--- a/xcp/cmd.py
+++ b/xcp/cmd.py
@@ -63,14 +63,13 @@ class OutputCache(object):
         self.cache = {}
 
     def fileContents(self, fn, *args, **kwargs):
-        open_defaults_for_utf8_text(args, kwargs)
+        mode = open_defaults_for_utf8_text(args, kwargs)
         key = 'file:' + fn
         if key not in self.cache:
             logger.debug("Opening " + fn)
             # pylint: disable=unspecified-encoding
-            f = open(fn, **kwargs)
-            self.cache[key] = ''.join(f.readlines())
-            f.close()
+            with open(fn, *args, **kwargs) as f:
+                self.cache[key] = f.read() if "b" in mode else "".join(f.readlines())
         return self.cache[key]
 
     def runCmd(self, command, with_stdout = False, with_stderr = False, inputtext = None):

--- a/xcp/compat.py
+++ b/xcp/compat.py
@@ -26,6 +26,8 @@ def open_defaults_for_utf8_text(args, kwargs):
     mode = other_kwargs.pop("mode", "")
     if args:
         mode = args[0]
+    if sys.version_info < (3, 0):
+        return mode, other_kwargs
     if not mode or not isinstance(mode, str):
         raise ValueError("The mode argument is required! r for text, rb for binary")
     if sys.version_info >= (3, 0) and "b" not in mode:

--- a/xcp/compat.py
+++ b/xcp/compat.py
@@ -24,6 +24,11 @@ def open_defaults_for_utf8_text(args, kwargs):
     """Setup keyword arguments for UTF-8 text mode with codec error handler to replace chars"""
 
     mode = kwargs.get("mode", "")
+    if args:
+        mode = args[0]
+    if not mode or not isinstance(mode, str):
+        raise ValueError("The mode argument is required! r|t for text, b for binary")
     if sys.version_info >= (3, 0) and "b" not in mode:
         kwargs.setdefault("encoding", "utf-8")
         kwargs.setdefault("errors", "replace")
+    return mode

--- a/xcp/compat.py
+++ b/xcp/compat.py
@@ -1,4 +1,4 @@
-"""Helper module for providing common defaults on how to enable UTF-8 I/O in Py3.6 and newer"""
+"""Helper module for setting up binary or UTF-8 I/O for Popen and open in Python 3.6 and newer"""
 # See README-Unicode.md for Details
 import sys
 
@@ -19,3 +19,11 @@ else:
     # Python2.7: None of the above is either supported or relevant (strings are bytes):
     open_utf8 = {}
     utf8open = open
+
+def open_defaults_for_utf8_text(args, kwargs):
+    """Setup keyword arguments for UTF-8 text mode with codec error handler to replace chars"""
+
+    mode = kwargs.get("mode", "")
+    if sys.version_info >= (3, 0) and "b" not in mode:
+        kwargs.setdefault("encoding", "utf-8")
+        kwargs.setdefault("errors", "replace")

--- a/xcp/compat.py
+++ b/xcp/compat.py
@@ -22,13 +22,13 @@ else:
 
 def open_defaults_for_utf8_text(args, kwargs):
     """Setup keyword arguments for UTF-8 text mode with codec error handler to replace chars"""
-
-    mode = kwargs.get("mode", "")
+    other_kwargs = kwargs.copy()
+    mode = other_kwargs.pop("mode", "")
     if args:
         mode = args[0]
     if not mode or not isinstance(mode, str):
-        raise ValueError("The mode argument is required! r|t for text, b for binary")
+        raise ValueError("The mode argument is required! r for text, rb for binary")
     if sys.version_info >= (3, 0) and "b" not in mode:
         kwargs.setdefault("encoding", "utf-8")
         kwargs.setdefault("errors", "replace")
-    return mode
+    return mode, other_kwargs


### PR DESCRIPTION
This PR enables Python3 support for `xcp.cmd`:
1. `fileContents()` uses `open()` which reads binary data a strings(are bytes in Python2)
   * Gets updates to select:
      * reading binary files in binary mode, returns binary data using the `bytes` type
        or
      * reading text files text with UTF-8 chars, returns the Unicode test using the `str` type.
2. `runCmd()` uses `Popen()` and which can likewise also open the `stdin`, `stdout`, `stderr` pipes as binary or attach text codecs to them for working with Unicode strings.
   - When `inputtext` (sent to `stdin`) is specified, it's type overrides the mode depending on it's data type being `str` or `bytes`.
   - If runCmd is asked to just run the command and not attach the `stdin`, `stdout`, `stderr` pipes, selecting a mode is superfluous.
   - Otherwise, the caller is required to specify the mode (text or binary mode)

PS: Codecov shows :100:% coverage of the changes library files is reached!