### PR TITLE
xcp.net.biosdevname: For Py3, add universal_newlines=True to Popen()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
     "pyfakefs",
     "pytest",
     "pytest-cov",
+    "pytest-forked",
     "pytest_httpserver; python_version >= '3.7'",
     "pytest-localftpserver; python_version >= '3.7'",
     "pytest-localftpserver==0.5.1; python_version <= '3.6'",

--- a/run-pytype.py
+++ b/run-pytype.py
@@ -115,9 +115,7 @@ def main(me: str, branch_url: str):
     )
     excludes = [
         "xcp/cmd.py",
-        "xcp/cpiofile.py",
         "xcp/net/ip.py",
-        "xcp/net/biosdevname.py",
     ]
     errors_in = excludes.copy()
     errors_in.extend(never)

--- a/tests/test_biosdevname.py
+++ b/tests/test_biosdevname.py
@@ -1,4 +1,6 @@
 import unittest
+from subprocess import PIPE
+
 from mock import patch, Mock
 
 from xcp.net.biosdevname import has_ppn_quirks, all_devices_all_names
@@ -26,7 +28,9 @@ class TestQuirks(unittest.TestCase):
 
 class TestDeviceNames(unittest.TestCase):
     def test(self):
+        # sourcery skip: extract-method, inline-immediately-returned-variable, path-read
         with patch("xcp.net.biosdevname.Popen") as popen_mock:
+            # pylint: disable=unspecified-encoding
             with open("tests/data/physical.biosdevname") as f:
                 fake_output_1 = f.read()
             with open("tests/data/all_ethN.biosdevname") as f:
@@ -43,6 +47,9 @@ class TestDeviceNames(unittest.TestCase):
         calls = popen_mock.call_args_list
         self.assertEqual(calls[0].args[0], ['/sbin/biosdevname', '--policy', 'physical', '-d'])
         self.assertEqual(calls[1].args[0], ['/sbin/biosdevname', '--policy', 'all_ethN', '-d'])
+        popen_kwargs = {"stdout": PIPE, "stderr": PIPE, "universal_newlines": True}
+        self.assertEqual(calls[0].kwargs, popen_kwargs)
+        self.assertEqual(calls[1].kwargs, popen_kwargs)
 
         self.assertEqual(devices['eth0']['BIOS device'],
                          {'all_ethN': 'eth0', 'physical': 'em1'})

--- a/tests/test_biosdevname_ns.py
+++ b/tests/test_biosdevname_ns.py
@@ -1,0 +1,31 @@
+"""Test biosdevname in a user namespace. Needs to be a new file because of a bug in pytest-forked"""
+import unittest
+from os import system
+
+import pytest  # type: ignore # for pyre in tox only
+import pytest_forked  # type: ignore # pylint: disable=unused-import # This needs pytest-forked
+
+import xcp.net.biosdevname
+
+from .xcptestlib_unshare import CLONE_NEWUSER, disassociate_namespaces
+
+
+def check_devices(self, devices):
+    for item in devices.items():
+        print(item[0])
+        print(item[1]["BIOS device"])
+        print(item[1]["Assigned MAC"])
+        print(item[1]["Bus Info"])
+        print(item[1]["Driver"])
+
+
+class TestDeviceNames(unittest.TestCase):
+    biosdevname_check = system("biosdevname --version")
+
+    @unittest.skipIf(biosdevname_check, "requires the biosdevname command to read interfaces")
+    @pytest.mark.forked  # The isolated network namespace would cause issues for other test cases
+    def test_calling_biosdevname(self):
+        disassociate_namespaces(CLONE_NEWUSER)
+        devices = xcp.net.biosdevname.all_devices_all_names()
+        self.assertGreater(len(devices), 0)
+        check_devices(self, devices)

--- a/tests/xcptestlib_unshare.py
+++ b/tests/xcptestlib_unshare.py
@@ -1,0 +1,24 @@
+import ctypes
+import os
+
+CLONE_NEWUSER = 0x10000000
+CLONE_NEWNET = 0x40000000
+
+
+def libc_unshare_syscall(flags):
+    """Wrapper for the unshare(2) libc function/system call to disassociate parts of the ucontext"""
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.unshare.argtypes = [ctypes.c_int]
+    rc = libc.unshare(flags)
+    if rc != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno), flags)
+
+
+def disassociate_namespaces(namespaces):
+    """unshare/disassociate parts of the process execution context and switch to new namespaces"""
+    uidmap = b"0 %d 1" % os.getuid()  # uidmap for the current uid in the new namespace
+    libc_unshare_syscall(namespaces)
+    if namespaces & CLONE_NEWUSER:  # Become root in the new user namespace if we created one:
+        with open("/proc/self/uid_map", "wb") as file_:
+            file_.write(uidmap)  #  Switch to uid=0 in the namespace to have root privileges

--- a/xcp/net/biosdevname.py
+++ b/xcp/net/biosdevname.py
@@ -42,7 +42,7 @@ def __run_all_devices(policy = "physical"):
     """
 
     proc = Popen(["/sbin/biosdevname", "--policy", policy,
-                  "-d"], stdout=PIPE, stderr=PIPE)
+                  "-d"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 
     stdout, stderr = proc.communicate()
 


### PR DESCRIPTION
Fixes `xcp.net.biosdevname` for Python3 by adding `universal_newlines=True`:
- Besides updating the mock test, this PR also adds a new test using `unshare()` to change the process context of the new test case into a new user namespace (biosdevname needs to run as root).
- Due to a known issue with pytest-forked (a part of pytest-xdist), the new test needs to be in a dedicated file.

PS: Because of the fixes, biosdevname and cpiofile no longer need to be excluded from the main pytype check run by run-pytype.py -> removed them from excludes!