### PR TITLE
Fix xcp.net.ip.ip_link_set_name() for Python3 and cover it with two testcases.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
     "pyfakefs",
     "pytest",
     "pytest-cov",
+    "pytest-forked",
     "pytest_httpserver; python_version >= '3.7'",
     "pytest-localftpserver; python_version >= '3.7'",
     "pytest-localftpserver==0.5.1; python_version <= '3.6'",

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -1,0 +1,78 @@
+"""tests/test_ip.py: Unit test for xcp/net/ip.py"""
+import ctypes
+import os
+import unittest
+from subprocess import PIPE
+
+import pytest  # type: ignore # for pyre in tox only
+import pytest_forked  # type: ignore # pylint: disable=unused-import # This needs pytest-forked
+from mock import Mock, patch
+
+import xcp.net.ip
+
+CLONE_NEWUSER = 0x10000000
+CLONE_NEWNET = 0x40000000
+
+
+def libc_unshare_syscall(flags):
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.unshare.argtypes = [ctypes.c_int]
+    rc = libc.unshare(flags)
+    if rc != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno), flags)
+
+
+def use_new_user_network_namespaces():
+    uidmap = b"0 %d 1" % os.getuid()  # uidmap for the current uid in the new namespace
+    libc_unshare_syscall(CLONE_NEWUSER | CLONE_NEWNET)
+    with open("/proc/self/uid_map", "wb") as file_:
+        file_.write(uidmap)  #  Switch to uid=0 in the new namespace to test ip_link_set_name()
+
+
+class TestIp(unittest.TestCase):
+    iproute2_check = os.system("ip address show lo")
+
+    @unittest.skipIf(iproute2_check, "requires the ip command to set interface names")
+    @pytest.mark.forked  # The isolated network namespace would cause issues for other test cases
+    @patch("xcp.net.ip.LOG.info")
+    def test_ip_link_set_name_in_netns(self, mock):
+        """Check that the "ip" calls of ip_link_set_name() actually work (in a network namespace)"""
+        use_new_user_network_namespaces()
+        xcp.net.ip.ip_link_set_name("lo", "lo0")
+        mock.assert_called_with("Succesfully renamed link lo to lo0")
+
+    def test_ip_link_set_name_mock(self):
+        """Check using "mock" that ip_link_set_name() calls "ip" with the expected arguments"""
+        with patch("xcp.net.ip.Popen") as popen_mock:
+            # Setup the return values and return codes returned by popen_mock:
+            ip_link_show_lo_stdout = (
+                "1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state"
+                "UNKNOWN mode DEFAULT group default qlen 1000"
+            )
+            communicate_mock = Mock(
+                side_effect=iter([(ip_link_show_lo_stdout, ""), ("", "")])
+            )
+            popen_mock.return_value.communicate = communicate_mock
+            popen_mock.return_value.returncode = 0
+
+            # Call the testee function with xcp.net.ip.Popen() mocked using popen_mock:
+            xcp.net.ip.ip_link_set_name("lo", "lo0")
+
+        # check the number or calls to Popen() by done by ip_link_set_name()
+        self.assertEqual(popen_mock.call_count, 4)
+
+        # check the captured regular arguments passed to Popen() by ip_link_set_name()
+        calls = popen_mock.call_args_list
+        self.assertEqual(calls[0].args, (["ip", "link", "show", "lo"],))
+        self.assertEqual(calls[1].args, (["ip", "link", "set", "lo", "down"],))
+        self.assertEqual(calls[2].args, (["ip", "link", "set", "lo", "name", "lo0"],))
+        self.assertEqual(calls[3].args, (["ip", "link", "set", "lo0", "up"],))
+
+        # check the captured keyword arguments passed to Popen() by ip_link_set_name()
+        expected_kwargs = {"universal_newlines": True}  # type: dict[str, bool | int]
+        self.assertEqual(calls[1].kwargs, expected_kwargs)
+        self.assertEqual(calls[2].kwargs, expected_kwargs)
+        self.assertEqual(calls[3].kwargs, expected_kwargs)
+        expected_kwargs["stdout"] = PIPE
+        self.assertEqual(calls[0].kwargs, expected_kwargs)

--- a/xcp/net/ip.py
+++ b/xcp/net/ip.py
@@ -53,7 +53,8 @@ def ip_link_set_name(src_name, dst_name):
     LOG.debug("Attempting rename %s -> %s" % (src_name, dst_name))
 
     # Is the interface currently up?
-    link_show = Popen(["ip", "link", "show", src_name], stdout = PIPE)
+    link_show = Popen(["ip", "link", "show", src_name], stdout = PIPE, universal_newlines=True)
+
     stdout, _ = link_show.communicate()
 
     if link_show.returncode != 0:
@@ -66,7 +67,7 @@ def ip_link_set_name(src_name, dst_name):
 
     # If it is up, bring it down for the rename
     if isup:
-        link_down = Popen(["ip", "link", "set", src_name, "down"])
+        link_down = Popen(["ip", "link", "set", src_name, "down"], universal_newlines=True)
         link_down.wait()
 
         if link_down.returncode != 0:
@@ -75,7 +76,7 @@ def ip_link_set_name(src_name, dst_name):
             return
 
     # Perform the rename
-    link_rename = Popen(["ip", "link", "set", src_name, "name", dst_name])
+    link_rename = Popen(["ip", "link", "set", src_name, "name", dst_name], universal_newlines=True)
     link_rename.wait()
 
     if link_rename.returncode != 0:
@@ -91,7 +92,7 @@ def ip_link_set_name(src_name, dst_name):
         # its final name.  However, i cant think of a non-hacky way of doing
         # this with the current implementation
 
-        link_up = Popen(["ip", "link", "set", dst_name, "up"])
+        link_up = Popen(["ip", "link", "set", dst_name, "up"], universal_newlines=True)
         link_up.wait()
 
         if link_up.returncode != 0:


### PR DESCRIPTION
Fixes `xcp.net.ip.ip_link_set_name()` for Python3 and covers it with two testcases.