### PR TITLE
tox.ini: Add requires for the tox envrionment itself and small updates

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,12 +9,22 @@
 envlist = py36-lint, py311-pyre, py39-check, py310-pytype, py37-mdreport, py38-covcombine
 isolated_build = true
 skip_missing_interpreters = true
+requires =
+    # The latest versions of tox need 'py>=1.11.0' and this is not stated in the deps of tox-4.5.1.
+    py>=1.11.0
+    # tox>=4 is needed in order to fix reading the python2.7 deps from pyproject.toml
+    tox>=4.5.1; python_version >= '3.7'
+    tox-gh-actions; python_version >= '3.7'
+    # virtualenv-20.22 breaks using python2.7 for the `py27` virtualenv with tox and newer
+    # versions even break py36(which is also EOL) because py36 does not support
+    # from __future__ import annotations
+    virtualenv<20.22
 
 [test]
 description = Run pytest in this environment with --cov for use in other stages
 extras      = test
 commands    =
-    pytest --cov -v {env:PYTEST_MD_REPORT} tests/
+    pytest --cov -v {env:PYTEST_MD_REPORT} --new-first -x --show-capture=all -rA
     sh -c 'ls -l {env:COVERAGE_FILE}'
     sh -c 'if [ -n "{env:PYTEST_MD_REPORT_OUTPUT}" -a -n "{env:GITHUB_STEP_SUMMARY}" ];then    \
       sed -i "s/tests\(.*py\)/[&](&)/" {env:PYTEST_MD_REPORT_OUTPUT}; sed "/title/,/\/style/d" \
@@ -74,6 +84,7 @@ passenv =
     fox: DBUS_SESSION_BUS_ADDRESS
 setenv =
     LC_ALL=C           # Ensure that xcp is tested without an locale (like XAPI plugins)
+    PYLINTHOME={envdir}/.pylinthome
     PYTHONDEVMODE=yes  # Enables development/resource checks: eg unclosed files and more
     PYTHONPATH=stubs
     # Inhibit dev-warnings on pytest plugins, but we enable dev-warnings in conftest.py
@@ -87,15 +98,15 @@ setenv =
     lint: ENVLOGDIR={envlogdir}
     {[cov]setenv}
 commands =
+    lint: {[lint]commands}
+    pyre: {[pyre]commands}
+    pytype: {[pytype]commands}
     {cov,covcp,covcombine,check,fox,lint,test,pytype,mdreport}: {[test]commands}
     # covcombine shall not call [cov]commands: diff-cover shall check the combined cov:
     {cov,covcp}: {[cov]commands}
     {py27-test}: pylint --py3k --disable=no-absolute-import xcp/
     covcp: cp -av {envlogdir}/coverage.xml {env:UPLOAD_DIR:.}
     covcombine: {[covcombine]commands}
-    pytype: {[pytype]commands}
-    lint: {[lint]commands}
-    pyre: {[pyre]commands}
     check: {[check]commands}
     fox: {[covcombine]commands}
     fox: {[lint]commands}
@@ -188,8 +199,8 @@ commands =
 [pyre]
 commands =
     pyre: python3.11 --version -V # Needs py311-pyre, does not work with py310-pyre
-    {[test]commands}
     python ./run-pyre.py
+    {[test]commands}
 
 [pytype]
 deps = pytype


### PR DESCRIPTION
I re-installed all my local Python environments and this forced me to notice how critical the top-level tox.ini:requires= config for the dependencies of tox itself are.

Without these taken care of, developers would run in to errors which are not easy to undertand and fix.

The problem is that for working with Python versions which are EOL since a long time like Python2.7 and 3.6, nobody cares any more and the maintainers are deploying code which is not compatible with those.

For example, to current versions of virtualenv use Python features which are only present in Python 3.7 and newer like dataclasses and from __future__ import annotations which 3.6 does not have and this then breaks the detection or the setup of environment of these older Python versions.

`tox.ini:requires=` now takes care of, that even if your enviroment is not completely on the required versions described in README.md, tox will still not fail in obscure ways because it will run in it's own virtualenv which it sets up itself.

The other changes are just to get better logs from CI and get the interesting logs on first.