### PR TITLE
tests/test_sbdfi_to_nic.py : Add test for `xcp.pci.pci_sbdfi_to_nic()`

### DIFF
--- a/stubs/pytest.pyi
+++ b/stubs/pytest.pyi
@@ -1,0 +1,8 @@
+# pylint: disable=reimported,no-name-in-module,unused-import,function-redefined.redefined-builtin
+from _pytest.python_api import raises
+from _typeshed import Incomplete as fixture
+from _typeshed import Incomplete as mark
+
+def skip(msg: str = "", *, allow_module_level: bool = False): ...
+
+__all__ = ["mark", "fixture", "skip", "raises"]

--- a/tests/test_sbdfi_to_nic.py
+++ b/tests/test_sbdfi_to_nic.py
@@ -1,0 +1,27 @@
+import pytest
+
+from xcp.pci import pci_sbdfi_to_nic
+
+nics = [
+    # One PCI NIC may have multiple MACs, see the comment in xcp/pci.py:
+    type("Nic", (object,), {"pci": "0000:01:00.0", "mac": "00:11:22:33:44:55"}),
+    type("Nic", (object,), {"pci": "0000:01:00.0", "mac": "00:11:22:33:44:56"}),
+    type("Nic", (object,), {"pci": "0000:02:00.0", "mac": "00:11:22:33:44:57"}),
+]
+
+
+def test_sbdf_index():
+    assert pci_sbdfi_to_nic("0000:01:00.0", nics) == nics[0]
+    assert pci_sbdfi_to_nic("0000:01:00.0[0]", nics) == nics[0]
+    assert pci_sbdfi_to_nic("0000:01:00.0[1]", nics) == nics[1]
+    assert pci_sbdfi_to_nic("0000:02:00.0", nics) == nics[2]
+    with pytest.raises(Exception) as e:
+        pci_sbdfi_to_nic("0000:01:00.0[3]", nics)
+        exp = "Insufficient NICs with PCI SBDF 0000:01:00.0 (Found 2, wanted at least 3)"
+        assert str(e) == exp
+    pytest.raises(Exception, pci_sbdfi_to_nic, "0000:03:00.0", nics)  # no matching SBDF
+    pytest.raises(Exception, pci_sbdfi_to_nic, "0000:01:00.1[2]", nics)  # Not enough MACs
+    pytest.raises(Exception, pci_sbdfi_to_nic, "0000:01:00.1[-1]", nics)  # Negative index
+    pytest.raises(Exception, pci_sbdfi_to_nic, "0000:01:00.0", [])
+    pytest.raises(Exception, pci_sbdfi_to_nic, "", nics)
+    pytest.raises(Exception, pci_sbdfi_to_nic, "", [])


### PR DESCRIPTION
When importing `xcp/pci.py` in Python 3.7 or newer, this warning appears:
```py
xcp/pci.py:40: FutureWarning: Possible nested set at position 146
    VALID_SBDFI = re.compile(
```
Fix it by adding the missing \ inside [\[] and inside [\]]:
```diff
-    r"  (?:[[](?P<index>[\d]{1,2})[]])?$"   # Index (optional)
+    r"  (?:[\[](?P<index>[\d]{1,2})[\]])?$"   # Index (optional)
```
The function using it, `pci_sbdfi_to_nic()` is indirectly tested by
- `xcp/net/ifrename/dynamic.py`
- `xcp/net/ifrename/static.py`
and this PR also
- adds a new dedicated test in `tests/test_sbdfi_to_nic.py` added in the 1st commit,
    - which passed in the 1st commit of this PR.
      (as shown by it's GitHub test results - it has a blue checkmark).

The fix of the regex is then applied in the 2nd commit.