### PR TITLE
.gitignore: Add cache directories used by CI and analysis tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,27 @@
 # Python bytecode files
 *.py[co]
+__pycache__/
 
 # Emacs backup files
 *~
+# Vim swap files
+*.swp
 
 # python coverage data
 .coverage
+
+# Python static analysis tool cache directories
+.mypy_cache/
+.pyre/
+.pytype/
+
+# Pytest cache
+.pytest_cache/
+
+# Tox {workdir} directory
+.tox/
+
 htmlcov/
+
+# Pip editable install directory
+python_libs.egg-info/


### PR DESCRIPTION
- Improve developer experience when the IDE has a feature to exclude the files in .gitignore from the file browser. E.g. in VS Code: `"explorer.excludeGitIgnore": true`
- Prevent accidentally adding cache directories to the git repo