### PR TITLE
tox.ini: Add GitHub ProblemMatcher for PYTHONWARNINGS from pytest runs

### DIFF
--- a/.github/workflows/PYTHONWARNINGS-problemMatcher.json
+++ b/.github/workflows/PYTHONWARNINGS-problemMatcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+        {
+            "owner": "python-libs-PYTHONWARNINGS",
+            "severity": "warning",
+            "pattern": [
+                {
+                    "regexp": "^.*/python-libs/(.+):([0-9]*):(.*):(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "code": 3,
+                    "message": 4
+                }
+            ]
+        }
+  ]
+}

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,9 @@ requires =
 description = Run pytest in this environment with --cov for use in other stages
 extras      = test
 commands    =
+    # https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md
+    # https://github.com/actions/toolkit/blob/main/docs/commands.md#problem-matchers
+    echo "::add-matcher::.github/workflows/PYTHONWARNINGS-problemMatcher.json"
     pytest --cov -v {env:PYTEST_MD_REPORT} --new-first -x --show-capture=all -rA
     sh -c 'ls -l {env:COVERAGE_FILE}'
     sh -c 'if [ -n "{env:PYTEST_MD_REPORT_OUTPUT}" -a -n "{env:GITHUB_STEP_SUMMARY}" ];then    \
@@ -60,6 +63,7 @@ deps =
     pytype: {[check]deps}
     pytype: {[pytype]deps}
 allowlist_externals =
+    {cov,covcp,covcombine,fox,check,lint,test,pytype,pyre,mdreport}: echo
     {cov,covcp,covcombine,fox,check,lint,test,pytype,pyre,mdreport}: sh
     {cov,covcp,covcombine,fox}: cp
     {covcombine,fox}: tox


### PR DESCRIPTION
# Show pytest warnings in Actions Summary & PR review

Adds a GitHub ProblemMatcher for PYTHONWARNINGS from pytest:

Examples for warnings which should be shown in the GitHub Action Summary and the Pull Request Review are:
- Unclosed files, Unclosed sockets
- Regex syntax warnings

Quote from example run: https://github.com/xenserver-next/python-libs/actions/runs/5121239216
```py
test (3.10, ubuntu-latest): xcp/repository.py#L193
unclosed file <_io.TextIOWrapper name='tests/data/repo/.treeinfo' encoding='utf-8'>
```
The warnings enabled for pytest are defined in tests/conftest.py using: 
```py
@pytest.fixture(autouse=True)
def set_warnings():
    # Enable ResourceWarning and other development warnings when running tests:
    warnings.simplefilter("default")
```
Documentation:
- https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md
- https://github.com/actions/toolkit/blob/main/docs/commands.md#problem-matchers