### PR TITLE
xcp/bootloader.py: Replace open() with open_with_codec_handling()

### DIFF
--- a/tests/test_bootloader.py
+++ b/tests/test_bootloader.py
@@ -6,6 +6,17 @@ from tempfile import NamedTemporaryFile, mkdtemp
 
 from xcp.bootloader import Bootloader
 
+
+def test_writeGrubWithTempFile(tmpdir):
+    """Test xcp.bootloader.{writeGrub,writeExtLinux}.open_with_codec_handling with tmpdir fixture"""
+    bootloader = Bootloader.readGrub2("tests/data/grub.cfg")
+    filename = str(tmpdir.mkdir("grub").join("menu.lst"))
+    bootloader.writeGrub(filename)
+    Bootloader.readGrub(filename)
+    bootloader.writeExtLinux(filename)
+    Bootloader.readExtLinux(filename)
+
+
 class TestBootloader(unittest.TestCase):
     def test_grub2(self):
         bl = Bootloader.readGrub2("tests/data/grub.cfg")

--- a/tests/test_bootloader.py
+++ b/tests/test_bootloader.py
@@ -5,6 +5,7 @@ import subprocess
 from tempfile import NamedTemporaryFile, mkdtemp
 
 from xcp.bootloader import Bootloader
+from xcp.compat import open_with_codec_handling
 
 
 def test_writeGrubWithTempFile(tmpdir):
@@ -40,13 +41,13 @@ class TestLinuxBootloader(unittest.TestCase):
         grubdir = os.path.join(bootdir, "grub")
         os.makedirs(grubdir)
         shutil.copyfile("tests/data/grub-linux.cfg", os.path.join(grubdir, "grub.cfg"))
-        with open(os.path.join(bootdir, "vmlinuz-1"), "w"):
+        with open_with_codec_handling(os.path.join(bootdir, "vmlinuz-1"), "w"):
             pass
-        with open(os.path.join(bootdir, "vmlinuz-2"), "w"):
+        with open_with_codec_handling(os.path.join(bootdir, "vmlinuz-2"), "w"):
             pass
-        with open(os.path.join(bootdir, "initrd.img-1"), "w"):
+        with open_with_codec_handling(os.path.join(bootdir, "initrd.img-1"), "w"):
             pass
-        with open(os.path.join(bootdir, "initrd.img-2"), "w"):
+        with open_with_codec_handling(os.path.join(bootdir, "initrd.img-2"), "w"):
             pass
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/xcp/bootloader.py
+++ b/xcp/bootloader.py
@@ -30,8 +30,13 @@ import os.path
 import re
 import tempfile
 import copy
+from typing import cast
+
 import branding
+
 import xcp.cmd
+
+from .compat import open_with_codec_handling
 
 COUNTER = 0
 
@@ -108,7 +113,7 @@ class Bootloader(object):
         title = None
         kernel = None
 
-        fh = open(src_file)
+        fh = open_with_codec_handling(src_file, encoding="utf-8")
         try:
             for line in fh:
                 l = line.strip()
@@ -216,7 +221,7 @@ class Bootloader(object):
             COUNTER += 1
             return "label%d" % COUNTER
 
-        fh = open(src_file)
+        fh = open_with_codec_handling(src_file, encoding="utf-8")
         try:
             for line in fh:
                 l = line.strip()
@@ -332,7 +337,7 @@ class Bootloader(object):
             COUNTER += 1
             return "label%d" % COUNTER
 
-        fh = open(src_file)
+        fh = open_with_codec_handling(src_file, encoding="utf-8")
         try:
             for line in fh:
                 l = line.strip()
@@ -462,7 +467,7 @@ class Bootloader(object):
         if hasattr(dst_file, 'name'):
             fh = dst_file
         else:
-            fh = open(dst_file, 'w')
+            fh = open_with_codec_handling(cast(str, dst_file), "w", encoding="utf-8")
         print("# location " + self.location, file=fh)
 
         if self.serial:
@@ -504,7 +509,7 @@ class Bootloader(object):
         if hasattr(dst_file, 'name'):
             fh = dst_file
         else:
-            fh = open(dst_file, 'w')
+            fh = open_with_codec_handling(cast(str, dst_file), "w", encoding="utf-8")
         print("# location " + self.location, file=fh)
 
         if self.serial:
@@ -538,7 +543,7 @@ class Bootloader(object):
         if hasattr(dst_file, 'name'):
             fh = dst_file
         else:
-            fh = open(dst_file, 'w')
+            fh = open_with_codec_handling(cast(str, dst_file), "w", encoding="utf-8")
 
         if self.serial:
             print("serial --unit=%s --speed=%s" % (self.serial['port'],


### PR DESCRIPTION
`xcp/bootloader.py`: Replace `open()` with `open_with_codec_handling()`:

- for Python2, this only adds a wrapper which does nothing, and
- for Python3, this adds `encoding="utf-8", errors="replace"` to `open()`

GRUB documentation states that it uses UTF-8 for all text files (including config), so it could be conceivable to encounter UTF-8 in/for them:

https://www.gnu.org/software/grub/manual/grub/html_node/Internationalisation.html

Adds a new testcase testing the new uses or `open_with_codec_handling()` in `writeGrub()` and `writeExtLinux()` 
