### PR TITLE
xcp/logger.py: Use open_with_codec_handling() for opening log files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,6 +18,7 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
+    if TYPE_CHECKING:
 
 precision = 1
 include =

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,33 @@
+"""Test xcp.logger.openLog()"""
+import os
+import sys
+from io import StringIO
+from pty import openpty
+
+from mock import mock_open, patch
+
+from xcp.compat import open_utf8
+from xcp.logger import openLog
+
+
+def test_openLog_mock_open():
+    """Cover xcp.logger.openLog.open_with_codec_handling and check the arguments used for open()"""
+    fh = StringIO()
+    with patch("xcp.compat.open", mock_open()) as open_mock:
+        open_mock.return_value = fh
+        assert openLog("test.log") is True
+        if sys.version_info >= (3, 0):
+            assert open_utf8 == {"encoding": "utf-8", "errors": "replace"}
+        else:
+            assert not open_utf8
+        open_mock.assert_called_once_with("test.log", "a", **open_utf8)
+
+
+def test_openLog_mock_stdin():
+    """Cover xcp.logger.openLog calling logging.StreamHandler(h) when h is a tty"""
+    with patch("xcp.compat.open", mock_open()) as open_mock:
+        master_fd, slave_fd = openpty()
+        open_mock.return_value = os.fdopen(slave_fd)
+        assert openLog("test.log") is True
+        os.close(slave_fd)
+        os.close(master_fd)

--- a/xcp/logger.py
+++ b/xcp/logger.py
@@ -32,8 +32,15 @@ import sys
 import traceback
 import logging
 import logging.handlers
+from typing import TYPE_CHECKING, TextIO
 
 from .compat import open_with_codec_handling
+
+if TYPE_CHECKING:
+    from typing import IO, Any, Union
+    from logging import StreamHandler
+    from logging.handlers import RotatingFileHandler
+    LoggingStreamHandler = Union[RotatingFileHandler, StreamHandler[IO[Any]], StreamHandler[TextIO]]
 
 LOG = logging.getLogger()
 LOG.setLevel(logging.NOTSET)
@@ -44,6 +51,7 @@ FORMAT = logging.Formatter(
 our_handlers = []
 
 def openLog(lfile, level=logging.INFO):
+    # type:(Union[str, TextIO], int) -> bool
     """Add a new file target to be logged to"""
 
     try:
@@ -51,7 +59,7 @@ def openLog(lfile, level=logging.INFO):
         if isinstance(lfile, str):
             h = open_with_codec_handling(lfile, "a")
             if h.isatty():
-                handler = logging.StreamHandler(h)
+                handler = logging.StreamHandler(h)  # type: LoggingStreamHandler
             else:
                 h.close()
                 handler = logging.handlers.RotatingFileHandler(lfile,

--- a/xcp/logger.py
+++ b/xcp/logger.py
@@ -33,6 +33,7 @@ import traceback
 import logging
 import logging.handlers
 
+from .compat import open_with_codec_handling
 
 LOG = logging.getLogger()
 LOG.setLevel(logging.NOTSET)
@@ -48,7 +49,7 @@ def openLog(lfile, level=logging.INFO):
     try:
         # if lfile is a string, assume we need to open() it
         if isinstance(lfile, str):
-            h = open(lfile, 'a')
+            h = open_with_codec_handling(lfile, "a")
             if h.isatty():
                 handler = logging.StreamHandler(h)
             else:


### PR DESCRIPTION
This PR ensures that xcp.logger works with non-ASCII characters in all Python vesrions in all cases (even in XAPI plugins with Python 3.6, when no UTF-8 locale is set).

It is split into three commits:
### 1. Wrap open() to use encoding="utf-8" and errors="replace" on Python3
Make xcp.logger not raise a codec error when writing non-ASCII data without a locale set.
### 2. Fix mypy  
Add typing information to the handler variable and openLog()
### 3. Add tests to provide code coverage for changes
The changes to `xcp/logger.py` need tests to cover the changed lines.