### PR TITLE
xcp/environ.py, xcp/dom0.py: Wrap open with open with codec handling

### DIFF
--- a/tests/test_dom0.py
+++ b/tests/test_dom0.py
@@ -30,7 +30,7 @@ class TestDom0(unittest.TestCase):
             (2*1024, 4*1024, 8*1024), # Above max
             ]
 
-        with patch("xcp.dom0.open") as open_mock:
+        with patch("xcp.dom0.open_with_codec_handling") as open_mock:
             for host_gib, dom0_mib, _ in test_values:
                 mock_version(open_mock, '2.8.0')
                 expected = dom0_mib * 1024;
@@ -39,7 +39,7 @@ class TestDom0(unittest.TestCase):
 
             open_mock.assert_called_with("/etc/xensource-inventory")
 
-        with patch("xcp.dom0.open") as open_mock:
+        with patch("xcp.dom0.open_with_codec_handling") as open_mock:
             for host_gib, _, dom0_mib in test_values:
                 mock_version(open_mock, '2.9.0')
                 expected = dom0_mib * 1024;

--- a/xcp/dom0.py
+++ b/xcp/dom0.py
@@ -28,7 +28,7 @@ from __future__ import division
 import re
 
 from . import version
-import sys
+from .compat import open_with_codec_handling
 
 def default_memory_v2(host_mem_kib):
     """Return the default for the amount of dom0 memory for the
@@ -82,7 +82,7 @@ def default_memory(host_mem_kib):
 
     # read current host version
     platform_version = None
-    with open("/etc/xensource-inventory") as f:
+    with open_with_codec_handling("/etc/xensource-inventory") as f:
         for l in f.readlines():
             line = l.strip()
             if line.startswith('PLATFORM_VERSION='):

--- a/xcp/environ.py
+++ b/xcp/environ.py
@@ -26,6 +26,8 @@
 import os
 import os.path
 
+from .compat import open_with_codec_handling
+
 EXTRA_SCRIPTS_DIR = '/mnt'
 
 def installerRunning():
@@ -45,7 +47,7 @@ def readInventory(root = '/'):
     try:
 
         try:
-            fh = open(os.path.join(root, 'etc/xensource-inventory'))
+            fh = open_with_codec_handling(os.path.join(root, "etc/xensource-inventory"))
 
             for line in (x for x in (y.strip() for y in fh)
                          if not x.startswith('#')):


### PR DESCRIPTION
Make xcp.environ and xcp.dom0 safe against raising UnicodeDecodeError() in all cases and versions:

Wrap open() using open_with_codec_handling()
- Ensures that inventory information is decoded from UTF-8 to Unicode strings properly to be future-proof.
- Fixes pylint: "Using open without explicitly specifying an encoding"