### PR TITLE
xcp/net/ifrename/dynamic.py,static.py: Wrap open to prevent codec errros

### DIFF
--- a/xcp/net/ifrename/dynamic.py
+++ b/xcp/net/ifrename/dynamic.py
@@ -32,6 +32,8 @@ beginning with a # character.
 
 from __future__ import unicode_literals
 
+from ...compat import open_with_codec_handling
+
 __version__ = "1.0.0"
 __author__  = "Andrew Cooper"
 
@@ -92,7 +94,7 @@ class DynamicRules(object):
                         LOG.error("Dynamic rule file '%s' does not exist"
                                   % (self.path,))
                         return False
-                    fd = open(self.path, "r")
+                    fd = open_with_codec_handling(self.path, "r")
                     raw_lines = fd.readlines()
 
                 # else if we were given a file descriptor, just read it
@@ -289,7 +291,7 @@ class DynamicRules(object):
             try:
                 # If we were given a path, try opening and writing to it
                 if self.path:
-                    fd = open(self.path, "w")
+                    fd = open_with_codec_handling(self.path, "w")
                     fd.write(self.write(header))
 
                 # else if we were given a file descriptor, just write to it

--- a/xcp/net/ifrename/static.py
+++ b/xcp/net/ifrename/static.py
@@ -42,6 +42,8 @@ Any line starting with '#' is considered to be a comment
 
 from __future__ import unicode_literals
 
+from ...compat import open_with_codec_handling
+
 __version__ = "1.1.1"
 __author__  = "Andrew Cooper"
 
@@ -115,7 +117,7 @@ class StaticRules(object):
                         LOG.error("Static rule file '%s' does not exist"
                                   % (self.path,))
                         return False
-                    fd = open(self.path, "r")
+                    fd = open_with_codec_handling(self.path, "r")
                     raw_lines = fd.readlines()
 
                 # else if we were given a file descriptor, just read it
@@ -327,7 +329,7 @@ class StaticRules(object):
             try:
                 # If we were given a path, try opening and writing to it
                 if self.path:
-                    fd = open(self.path, "w")
+                    fd = open_with_codec_handling(self.path, "w")
                     fd.write(self.write(header))
 
                 # else if we were given a file descriptor, just read it


### PR DESCRIPTION
Fixes pylint: "Using open without explicitly specifying an encoding" for:
* xcp/net/ifrename/static.py
* xcp/net/ifrename/dynamic.py

Dynamic and static rules files should not contain non-ASCII bytes...

.. but to be safe against that, use the prepared wrapper for open.

It calls open() with errors="replace" to replace any malformed input bytes.

Fixes pylint: "Using open without explicitly specifying an encoding"