### PR TITLE
test_ifrename_*.py: Fixup pylint, allow method-length of 34 chars

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -106,10 +106,10 @@ const-rgx=(([a-zA-Z_][a-zA-Z0-9_]*)|(__.*__))$
 class-rgx=[A-Z_][a-zA-Z0-9]+$
 
 # Regular expression which should only match correct function names
-function-rgx=[a-z_][a-zA-Z0-9_]{2,30}$
+function-rgx=[a-z_][a-zA-Z0-9_]{2,34}$
 
 # Regular expression which should only match correct method names
-method-rgx=[a-z_][a-zA-Z0-9_]{2,30}$
+method-rgx=[a-z_][a-zA-Z0-9_]{2,34}$
 
 # Regular expression which should only match correct instance attribute names
 attr-rgx=[a-z_][a-zA-Z0-9_]{0,30}$

--- a/tests/test_ifrename_dynamic.py
+++ b/tests/test_ifrename_dynamic.py
@@ -2,13 +2,12 @@ from __future__ import unicode_literals
 import json
 import logging
 import unittest
-from copy import deepcopy
 
 from io import StringIO
 
 from xcp.net.ifrename.dynamic import DynamicRules
 from xcp.net.ifrename.macpci import MACPCI
-from xcp.logger import LOG, openLog, closeLogs
+from xcp.logger import openLog, closeLogs
 
 
 class TestLoadAndParse(unittest.TestCase):

--- a/tests/test_ifrename_logic.py
+++ b/tests/test_ifrename_logic.py
@@ -1,3 +1,4 @@
+# pyright: reportGeneralTypeIssues=false
 from __future__ import print_function
 from __future__ import unicode_literals
 import logging
@@ -7,8 +8,9 @@ from copy import deepcopy
 
 from io import StringIO
 
+# pylint:disable=wildcard-import,unused-wildcard-import,invalid-name,use-implicit-booleaness-not-len
 from xcp.net.ifrename.logic import *
-from xcp.logger import LOG, openLog, closeLogs
+from xcp.logger import openLog, closeLogs
 
 def apply_transactions(lst, trans):
 

--- a/tests/test_ifrename_static.py
+++ b/tests/test_ifrename_static.py
@@ -1,13 +1,12 @@
 from __future__ import unicode_literals
 import logging
 import unittest
-from copy import deepcopy
 
 from io import StringIO
 
 from xcp.net.ifrename.static import StaticRules
 from xcp.net.ifrename.macpci import MACPCI
-from xcp.logger import LOG, openLog, closeLogs
+from xcp.logger import openLog, closeLogs
 
 
 class TestLoadAndParse(unittest.TestCase):


### PR DESCRIPTION
Trivial minor `pylint` cleanup PR for:
* `tests/test_ifrename_dynamic.py`
* `tests/test_ifrename_logic.py`
* `tests/test_ifrename_static.py` 

Diffstat:
```js
git log -n1 -p |diffstat
 pylintrc                       |    4 ++--
 tests/test_ifrename_dynamic.py |    3 +--
 tests/test_ifrename_logic.py   |    4 +++-
 tests/test_ifrename_static.py  |    3 +--
 4 files changed, 7 insertions(+), 7 deletions(-)
```
Change summary:
- `tests/test_ifrename_*.py`: Fix unused-import warnings
- `pylintrc`: allow methods with 34 characters and relax the type checking of pyright for test_ifrename_logic.py