### PR TITLE
tests/test_bootloader.py: Add missing tests and fixup pylint

### DIFF
--- a/tests/test_bootloader.py
+++ b/tests/test_bootloader.py
@@ -15,8 +15,9 @@ class TestBootloader(unittest.TestCase):
             proc = subprocess.Popen(["diff", "tests/data/grub.cfg", temp.name],
                                     stdout = subprocess.PIPE,
                                     universal_newlines=True)
+        assert proc.stdout
         for line in proc.stdout:
-            # FIXME: check is entirely ad-hoc, should we have a diff at all ?
+            # pylint: disable-next=deprecated-method
             self.assertRegexpMatches(line, r"^(5a6,13$|>)")
 
         proc.stdout.close()
@@ -45,15 +46,61 @@ class TestLinuxBootloader(unittest.TestCase):
 class TestBootloaderAdHoc(unittest.TestCase):
     def setUp(self):
         self.bl = Bootloader.readGrub2("tests/data/grub.cfg")
+        check_config(self.bl)
 
     def test_grub(self):
         with NamedTemporaryFile("w", delete=False) as temp:
             self.bl.writeGrub(temp)
         bl2 = Bootloader.readGrub(temp.name)
+        # Check config from tests/data/grub.cfg:
         os.unlink(temp.name)
+        assert bl2.serial == {"port": 0, "baud": 115200}
+        check_config(bl2)
 
     def test_extlinux(self):
         with NamedTemporaryFile("w", delete=False) as temp:
             self.bl.writeExtLinux(temp)
         bl2 = Bootloader.readExtLinux(temp.name)
         os.unlink(temp.name)
+        # readExtLinux tries to read flow-control (there is none in tests/data/grub.cfg):
+        assert bl2.serial == {"port": 0, "baud": 115200, "flow": None}
+        check_config(bl2)
+
+
+def check_config(bl):
+    # Check config from tests/data/grub.cfg:
+    assert bl.timeout == 50  # xcp.bootloader multiples and divides the timeout by 10
+    assert bl.default == "xe"
+    assert bl.location == "mbr"
+    assert sorted(bl.menu.keys()) == sorted(
+        ["xe", "xe-serial", "safe", "fallback", "fallback-serial"]
+    )
+    assert bl.menu["xe"].title == "XCP-ng"
+    assert bl.menu["xe"].hypervisor == "/boot/xen.gz"
+    assert bl.menu["xe"].hypervisor_args == " ".join(
+        (
+            "dom0_mem=7584M,max:7584M",
+            "watchdog",
+            "ucode=scan",
+            "dom0_max_vcpus=1-16",
+            "crashkernel=256M,below=4G",
+            "console=vga",
+            "vga=mode-0x0311",
+        )
+    )
+    assert bl.menu["xe"].kernel == "/boot/vmlinuz-4.19-xen"
+    assert bl.menu["xe"].kernel_args == " ".join(
+        (
+            "root=LABEL=root-vgdorj",
+            "ro",
+            "nolvm",
+            "hpet=disable",
+            "console=hvc0",
+            "console=tty0",
+            "quiet",
+            "vga=785",
+            "splash",
+            "plymouth.ignore-serial-consoles",
+        )
+    )
+    assert bl.menu["xe"].initrd == "/boot/initrd-4.19-xen.img"


### PR DESCRIPTION
## Improve the testase tests/test_bootloader.py

- Verify the results from reading `tests/data/grub.cfg`:
  - After verifying the initial load,
  - save the loaded configuration to a temporary file and
  - read them again, and re-verify the red configuration to be yield the same settings
- Fixup pylint warnings

Diffstat:
```ts
git log -n1 -p |diffstat
 test_bootloader.py |   49 ++++++++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 48 insertions(+), 1 deletion(-)
```