### PR TITLE
xcp/bootloader.py: Fix pyright: reportOptionalMemberAccess

### DIFF
--- a/xcp/bootloader.py
+++ b/xcp/bootloader.py
@@ -459,7 +459,7 @@ class Bootloader(object):
             raise RuntimeError("No existing bootloader configuration found")
 
     def writeExtLinux(self, dst_file = None):
-        if hasattr(dst_file, 'name'):
+        if dst_file and hasattr(dst_file, 'name'):
             fh = dst_file
         else:
             fh = open(dst_file, 'w')
@@ -501,7 +501,7 @@ class Bootloader(object):
             fh.close()
 
     def writeGrub(self, dst_file = None):
-        if hasattr(dst_file, 'name'):
+        if dst_file and hasattr(dst_file, 'name'):
             fh = dst_file
         else:
             fh = open(dst_file, 'w')
@@ -535,7 +535,7 @@ class Bootloader(object):
             fh.close()
 
     def writeGrub2(self, dst_file = None):
-        if hasattr(dst_file, 'name'):
+        if dst_file and hasattr(dst_file, 'name'):
             fh = dst_file
         else:
             fh = open(dst_file, 'w')


### PR DESCRIPTION
Silence `reportOptionalMemberAccess` `pyright`  errors in `xcp/bootloader.py`:
```py
bootloader.py:506:16 - error: "close" is not a known member of "None" (reportOptionalMemberAccess)
bootloader.py:540:16 - error: "close" is not a known member of "None" (reportOptionalMemberAccess)
bootloader.py:608:16 - error: "close" is not a known member of "None" (reportOptionalMemberAccess)
```

The cause is that `dst_file` is passed as Optional which can be None, and only checked using `hasattr(dstfile, None)` which does not cause `pyright` to recoginze it as not None.

Add an explicit check for it to be not Null, to fix these analysis errors in for pyright CI and vscode.