### PR TITLE
tests/test_ftpaccessor.py: Add check to cover FTPAccessor._cleanup()

### DIFF
--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -30,3 +30,11 @@ class TestAccessor(unittest.TestCase):
 
         a = xcp.accessor.FilesystemAccessor("tests/data/repo/", True)
         self.check_repo_access(a)
+
+
+def test_access_handles_exception():
+    class AccessorHandlesException(xcp.accessor.Accessor):
+        def openAddress(self, address):
+            raise IOError("Test Accessor.access returning False on Exception to cove code")
+
+    assert AccessorHandlesException(True).access("filename") is False

--- a/tests/test_ftpaccessor.py
+++ b/tests/test_ftpaccessor.py
@@ -71,4 +71,5 @@ def test_download_binary_file(ftp_accessor):
     """Download a binary file and compare the returned file content"""
     remote_ftp_filehandle = ftp_accessor.openAddress("filename")
     assert remote_ftp_filehandle.read() == binary_data
+    assert ftp_accessor.access("filename") is True  # covers FTPAccessor._cleanup()
     ftp_accessor.finish()

--- a/xcp/accessor.py
+++ b/xcp/accessor.py
@@ -64,8 +64,8 @@ class Accessor(object):
             f = self.openAddress(name)
             if not f:
                 return False
-            f.close()
-        except Exception as e:
+            f.close()  # pylint: disable=no-member
+        except Exception:
             return False
 
         return True

--- a/xcp/accessor.py
+++ b/xcp/accessor.py
@@ -33,8 +33,7 @@ from typing import cast, TYPE_CHECKING
 
 from six.moves import urllib  # pyright: ignore
 
-import xcp.mount as mount
-import xcp.logger as logger
+from xcp import logger, mount
 
 if TYPE_CHECKING:
     from typing import IO

--- a/xcp/accessor.py
+++ b/xcp/accessor.py
@@ -29,11 +29,16 @@ import ftplib
 import os
 import tempfile
 import errno
+from typing import cast, TYPE_CHECKING
 
 from six.moves import urllib  # pyright: ignore
 
 import xcp.mount as mount
 import xcp.logger as logger
+
+if TYPE_CHECKING:
+    from typing import IO
+    from typing_extensions import Literal
 
 # maps errno codes to HTTP error codes
 # needed for error code consistency
@@ -67,8 +72,9 @@ class Accessor(object):
         return True
 
     def openAddress(self, address):
-        """should be overloaded"""
-        pass
+        # type:(str) -> IO[bytes] | Literal[False]
+        """must be overloaded"""
+        return False  # pragma: no cover
 
     def canEject(self):
         return False
@@ -265,7 +271,7 @@ class FTPAccessor(Accessor):
     def _cleanup(self):
         if self.cleanup:
             # clean up after RETR
-            self.ftp.voidresp()
+            cast(ftplib.FTP, self.ftp).voidresp()
             self.cleanup = False
 
     def start(self):
@@ -275,9 +281,9 @@ class FTPAccessor(Accessor):
             port = ftplib.FTP_PORT
             if self.url_parts.port:
                 port = self.url_parts.port
-            self.ftp.connect(self.url_parts.hostname, port)
-            username = self.url_parts.username
-            password = self.url_parts.password
+            self.ftp.connect(cast(str, self.url_parts.hostname), port)
+            username = cast(str, self.url_parts.username)
+            password = cast(str, self.url_parts.password)
             if username:
                 username = urllib.parse.unquote(username)
             if password:
@@ -296,7 +302,7 @@ class FTPAccessor(Accessor):
             return
         self.start_count -= 1
         if self.start_count == 0:
-            self.ftp.quit()
+            cast(ftplib.FTP, self.ftp).quit()
             self.cleanup = False
             self.ftp = None
 
@@ -306,6 +312,7 @@ class FTPAccessor(Accessor):
             self._cleanup()
             url = urllib.parse.unquote(path)
 
+            assert self.ftp
             if self.ftp.size(url) is not None:
                 return True
             lst = self.ftp.nlst(os.path.dirname(url))
@@ -331,6 +338,7 @@ class FTPAccessor(Accessor):
         self._cleanup()
         url = urllib.parse.unquote(address)
 
+        assert self.ftp
         self.ftp.voidcmd('TYPE I')
         socket = self.ftp.transfercmd('RETR ' + url)
         buffered_reader = socket.makefile('rb')
@@ -344,7 +352,7 @@ class FTPAccessor(Accessor):
         fname = urllib.parse.unquote(out_name)
 
         logger.debug("Storing as " + fname)
-        self.ftp.storbinary('STOR ' + fname, in_fh)
+        cast(ftplib.FTP, self.ftp).storbinary('STOR ' + fname, in_fh)
 
     def __repr__(self):
         return "<FTPAccessor: %s>" % self.baseAddress


### PR DESCRIPTION
Fix warnings in `xcp/accessor.py` and add new tests, raises code coverage by 1% according to CodeCov.
(In total, we went from 69% to 75% so far)

### Commit 1
- [tests/test_ftpaccessor.py: Add check to cover FTPAccessor._cleanup()](https://github.com/xenserver/python-libs/pull/69/commits/578d856d64eca340bdba68eb6ee903299f05a770)
   - Add a call to `FTPAccessor.access()` after `FTPAccessor.openAddress()`:
       - `FTPAccessor._cleanup()` is now tested and covered.
### Commit 2
- [xcp/accessor.py: Fix warnings on FTPAccessor.ftp not None](https://github.com/xenserver/python-libs/pull/69/commits/20f0e65aa000daf9024a4f22c95626acc9bce32b)
  - Fix return value of abstract/base method Accessor.openAddress
  - Cast/assert FTPAccessor.ftp because it is None before start()
### Commit 3
- [xcp/accessor.py: Fix pylint message for import of xcp.logger and .mount](https://github.com/xenserver/python-libs/pull/69/commits/44ae267584469b0b4c7978772ac6da963cde9c82)
   - Update of the import to from an old akward form to **`from xcp import logger, mount`**
### Commit 4
- [xcp/accessor.py: Fix pylint warings in Accessor.openAddress()](https://github.com/xenserver/python-libs/pull/69/commits/eab0f20cf7998dd51a356b1220677788517b1ac6):
    - Disable the pylint:no-member warning in Accessor.access() because
      Accessor.openAddress() can only return False, not a IO[bytes]/file
    - Fix unused variable warning for Exception e in the same funcion
    - Add a new test case covering the changed "except Exception:" line