### PR TITLE
xcp/accessor.py: Fix/Disable the remaining pylint warnings

### DIFF
--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -3,9 +3,20 @@ import unittest
 import xcp.accessor
 
 class TestAccessor(unittest.TestCase):
+    def setUp(self):
+        """Provide the refrence content of the repo/.treeinfo file for check_repo_access()"""
+        with open("tests/data/repo/.treeinfo", "rb") as dot_treeinfo:
+            self.reference_treeinfo = dot_treeinfo.read()
+
     def check_repo_access(self, a):
         """Common helper function for testing Accessor.access() with repo files"""
         a.start()
+
+        treeinfo_file = a.openAddress('.treeinfo')
+        assert not isinstance(treeinfo_file, bool)  # check to not return False, pytype alerts on it
+        assert treeinfo_file.read() == self.reference_treeinfo
+        treeinfo_file.close()
+
         self.assertTrue(a.access('.treeinfo'))
         self.assertFalse(a.access('no_such_file'))
         self.assertEqual(a.lastError, 404)

--- a/xcp/accessor.py
+++ b/xcp/accessor.py
@@ -217,7 +217,7 @@ class FileAccessor(Accessor):
 
     def openAddress(self, address):
         try:
-            file = open(os.path.join(self.baseAddress, address), "rb")
+            reader = open(os.path.join(self.baseAddress, address), "rb")
         except IOError as e:
             if e.errno == errno.EIO:
                 self.lastError = 5
@@ -233,7 +233,7 @@ class FileAccessor(Accessor):
         except Exception as e:
             self.lastError = 500
             return False
-        return file
+        return reader
 
     def writeFile(self, in_fh, out_name):
         logger.info("Copying to %s" % os.path.join(self.baseAddress, out_name))
@@ -300,7 +300,7 @@ class FTPAccessor(Accessor):
             self.cleanup = False
             self.ftp = None
 
-    def access(self, path):
+    def access(self, path):  # pylint: disable=arguments-differ,arguments-renamed
         try:
             logger.debug("Testing "+path)
             self._cleanup()
@@ -388,7 +388,7 @@ SUPPORTED_ACCESSORS = {'nfs': NFSAccessor,
                        'ftp': FTPAccessor,
                        'file': FileAccessor,
                        'dev': DeviceAccessor,
-                       }
+                      }
 
 def createAccessor(baseAddress, *args):
     url_parts = urllib.parse.urlsplit(baseAddress, allow_fragments=False)


### PR DESCRIPTION
## xcp/accessor.py: Fix the remaining pylint warnings

- Fix pylint:argument-differs:
  FTPAccessor.access(path) does not match Accessor.access(name)
  (arguments-differ in overridden method).
  - Disable the warning to not break any existing calls which might use
    these calling arguments:
    - FTPAccessor.access(path=...)
    - (any other)Accessor.access(name=...)
  (To be sure, grep/pylint would have to be used in all callers)
- Fix not assigning a value to the builtin "file".
- Fix indentation of closing "}"



