### PR TITLE
xcp/accessor.py: Fix pylint-py3 warning on duplicate exceptions

### DIFF
--- a/xcp/accessor.py
+++ b/xcp/accessor.py
@@ -102,13 +102,7 @@ class FilesystemAccessor(Accessor):
     def openAddress(self, address):
         try:
             filehandle = open(os.path.join(self.location, address), "rb")
-        except OSError as e:
-            if e.errno == errno.EIO:
-                self.lastError = 5
-            else:
-                self.lastError = mapError(e.errno)
-            return False
-        except IOError as e:
+        except (IOError, OSError) as e:
             if e.errno == errno.EIO:
                 self.lastError = 5
             else:
@@ -223,13 +217,7 @@ class FileAccessor(Accessor):
     def openAddress(self, address):
         try:
             file = open(os.path.join(self.baseAddress, address), "rb")
-        except IOError as e:
-            if e.errno == errno.EIO:
-                self.lastError = 5
-            else:
-                self.lastError = mapError(e.errno)
-            return False
-        except OSError as e:
+        except (IOError, OSError) as e:
             if e.errno == errno.EIO:
                 self.lastError = 5
             else:
@@ -316,13 +304,7 @@ class FTPAccessor(Accessor):
                 return True
             lst = self.ftp.nlst(os.path.dirname(url))
             return os.path.basename(url) in list(map(os.path.basename, lst))
-        except IOError as e:
-            if e.errno == errno.EIO:
-                self.lastError = 5
-            else:
-                self.lastError = mapError(e.errno)
-            return False
-        except OSError as e:
+        except (IOError, OSError) as e:
             if e.errno == errno.EIO:
                 self.lastError = 5
             else:


### PR DESCRIPTION
Fix warnings on identical exception handlers for OSError and IOError:

On Python >= 3.3, `IOError` is a simple alias of OSError, but that wasn't the case for 2.7:
- Catch both exceptions in the same except block, which is no change for Python2.
- Fixes the pylint warning (and eliminates duplicated code).