### PR TITLE
xcp/repository.py: Fixup unclosed file warning left from #27

### DIFF
--- a/xcp/repository.py
+++ b/xcp/repository.py
@@ -136,7 +136,6 @@ class BaseRepository(object):
         access.start()
         is_yum = YumRepository.isRepo(access, "")
         access.finish()
-        
         if is_yum:
             return YumRepository.getRepoVer(access)
         return Repository.getRepoVer(access)
@@ -190,7 +189,8 @@ class YumRepository(BaseRepository):
                 treeinfofp = io.TextIOWrapper(rawtreeinfofp, encoding='utf-8')
             treeinfo = configparser.ConfigParser()
             treeinfo.read_file(treeinfofp)
-            treeinfofp = None
+            if treeinfofp != rawtreeinfofp:
+                treeinfofp.close()
             rawtreeinfofp.close()
             if treeinfo.has_section('system-v1'):
                 ver_str = treeinfo.get('system-v1', category_map[category])


### PR DESCRIPTION
Simple 2-line PR:

* Fixup the unclosed file warning which was introduced by commit 08f000
(xcp.repository: switch from ConfigParser to configparser) from PR #27.

* PS: Because I'm using pre-commit now:
  Also remove a line which had trailing spaces