### PR TITLE
Add Accessor.openText() as context manager for openAddress()

### DIFF
--- a/tests/test_httpaccessor.py
+++ b/tests/test_httpaccessor.py
@@ -1,4 +1,5 @@
 """Test xcp.accessor.HTTPAccessor using a local pure-Python http(s)server fixture"""
+# -*- coding: utf-8 -*-
 import base64
 import sys
 import unittest
@@ -16,6 +17,8 @@ try:
 except ImportError:
     pytest.skip(allow_module_level=True)
 
+
+UTF8TEXT_LITERAL = "✋Hello accessor from the 🗺, download and verify me! ✅"
 
 class HTTPAccessorTestCase(unittest.TestCase):
     document_root = "tests/"
@@ -109,3 +112,10 @@ class HTTPAccessorTestCase(unittest.TestCase):
             + ".pyc"
         )
         self.assert_http_get_request_data(self.httpserver.url_for(""), binary, None)
+
+    def test_httpaccessor_open_text(self):
+        """Get text containing UTF-8 and compare the returned decoded string contents"""
+        self.httpserver.expect_request("/textfile").respond_with_data(UTF8TEXT_LITERAL)
+        accessor = createAccessor(self.httpserver.url_for("/"), True)
+        with accessor.openText("textfile") as textfile:
+            assert textfile.read() == UTF8TEXT_LITERAL

--- a/xcp/repository.py
+++ b/xcp/repository.py
@@ -24,11 +24,9 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from hashlib import md5
-import io
 import os.path
 import xml.dom.minidom
 import configparser
-import sys
 
 import six
 
@@ -180,18 +178,11 @@ class YumRepository(BaseRepository):
 
         access.start()
         try:
-            rawtreeinfofp = access.openAddress(cls.TREEINFO_FILENAME)
-            if sys.version_info < (3, 0) or isinstance(rawtreeinfofp, io.TextIOBase):
-                # e.g. with FileAccessor
-                treeinfofp = rawtreeinfofp
-            else:
-                # e.g. with HTTPAccessor
-                treeinfofp = io.TextIOWrapper(rawtreeinfofp, encoding='utf-8')
             treeinfo = configparser.ConfigParser()
-            treeinfo.read_file(treeinfofp)
-            if treeinfofp != rawtreeinfofp:
-                treeinfofp.close()
-            rawtreeinfofp.close()
+
+            with access.openText(cls.TREEINFO_FILENAME) as fp:
+                treeinfo.read_file(fp)
+
             if treeinfo.has_section('system-v1'):
                 ver_str = treeinfo.get('system-v1', category_map[category])
             else:


### PR DESCRIPTION
The commits on this PR depend on the 1st commit:

It adds `Accessor.openText()` as a new API to make uses like `ConfigParser().read_file(TextIO)` which need `TextIO`(`IO[str]`). It replaces calls like these (change commit: https://github.com/xenserver/python-libs/commit/a97be270bd9949735ecbb8f6ae25c0756775d101?diff=split)
```py
           rawtreeinfofp = access.openAddress(cls.TREEINFO_FILENAME)
            if sys.version_info < (3, 0) or isinstance(rawtreeinfofp, io.TextIOBase):
                # e.g. with FileAccessor
                treeinfofp = rawtreeinfofp
            else:
                # e.g. with HTTPAccessor
                treeinfofp = io.TextIOWrapper(rawtreeinfofp, encoding='utf-8')
            treeinfo = configparser.ConfigParser()
            treeinfo.read_file(treeinfofp)
            if treeinfofp != rawtreeinfofp:
                treeinfofp.close()
            rawtreeinfofp.close()
```
with:
```py
            with access.openText(cls.TREEINFO_FILENAME) as fp:
                treeinfo.read_file(fp)
```
It makes it easy to use `TextIO`(`IO[str]`) with `xcp.accessor` on Python3 by using a context manager which takes care of closing all buffers/readers after leaving the context:
- [`xcp/accessor.py`: `openText()`: Context manager to read text from addr](https://github.com/xenserver/python-libs/pull/76/commits/77028d9199a27a641195bf02771911b76cb2386d)

  Add `Accessor.openText()` as context manager to wrap `openAddress()` with `io.TextIOWrapper` (if needed which is what Yann Dirson did as well in PR #17/#27):
  - `Accessor.openText()`:
     - Yields a `TextIOWrapper` (or instance of `IO[str]`) or `False`
     - On leaving the context, closes the created `TextIOWrapper` and the underlying `file` 

  It is intented for use in `xcp.repository` and in any other user requiring text as string without having to call `.decode()` after reading the returned file object.
- [`xcp/repository.py`: Use `Accessor.openText()` for `ConfigParser()`](https://github.com/xenserver/python-libs/pull/76/commits/a97be270bd9949735ecbb8f6ae25c0756775d101)

  Use `Accessor.openText()` in `_getVersion()` for `ConfigParser().read_file()`.
  It simplifies `_getVersion()` dramatically and causes `Accessor.openText()` to be tested with `xcp.accessor.FileAccessor` and `xcp.accessor.HTTPAccessor`.
- [tests/test_mountingaccessor.py: Test MountingAccessor.openText()](https://github.com/xenserver/python-libs/pull/76/commits/bf9a513d2d12c30432f669aac26d64c1a57598fb)

  Test openText() with subclasses of xcp.accessor.MountingAccessor
- [tests/test_ftpaccessor.py: Test FTPAccessor.openText()](https://github.com/xenserver/python-libs/pull/76/commits/3e2e7d39bb527b0576af3e3c5fe32407b1071d06)

  New test: Download a text file containing UTF-8 using `FTPAccessor.openText()` and compare the returned string.

- [tests/test_httpaccessor.py: Add test for HTTPAccessor.openText()](https://github.com/xenserver/python-libs/pull/76/commits/8cbe626834377bf027a064ca8fa38787c44d5405)

  Add test to get text containing UTF-8 using HTTPAccessor.openText() and compare the returned decoded string contents.
- [tests/test_httpaccessor.py: Split assert_http_get_request_data()](https://github.com/xenserver/python-libs/pull/76/commits/eb14ba02d7f58aa25edc2859b3db02cb794754d8)

  Split `assert_http_get_request_data()` using `contextlib.contextmanager`