### PR TITLE
Update FileAcessor.writeFile() to support writing binary files

### DIFF
--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -1,6 +1,19 @@
 import unittest
 
+from pyfakefs.fake_filesystem import FakeFilesystem
+
 import xcp.accessor
+
+from .test_mountingaccessor import check_binary_read, check_binary_write
+
+
+def test_file_accessor(fs):
+    # type:(FakeFilesystem) -> None
+    """Test FileAccessor.writeFile(), .openAddress and .access using pyfakefs"""
+    accessor = xcp.accessor.createAccessor("file://repo/", False)
+    check_binary_read(accessor, "/repo", fs)
+    check_binary_write(accessor, "/repo", fs)
+
 
 class TestAccessor(unittest.TestCase):
     def setUp(self):
@@ -28,12 +41,6 @@ class TestAccessor(unittest.TestCase):
         # Temporary: To be obsoleted by a dedicated test case using a pytest-native
         # httpd which will cover code paths like HTTP Basic Auth in an upcoming commit:
         a = xcp.accessor.createAccessor("https://updates.xcp-ng.org/netinstall/8.2.1", True)
-        self.check_repo_access(a)
-
-    def test_file(self):
-        """Test FileAccessor.access()"""
-
-        a = xcp.accessor.createAccessor("file://tests/data/repo/", True)
         self.check_repo_access(a)
 
     def test_filesystem_accessor_access(self):

--- a/tests/test_mountingaccessor.py
+++ b/tests/test_mountingaccessor.py
@@ -63,6 +63,8 @@ def check_binary_read(accessor, location, fs):
     assert fs.create_file(path, contents=cast(str, binary_data))
 
     assert accessor.access(name)
+    assert accessor.access("nonexisting filename") is False
+    assert accessor.lastError == 404
 
     binary_file = accessor.openAddress(name)
     assert not isinstance(binary_file, bool)

--- a/xcp/accessor.py
+++ b/xcp/accessor.py
@@ -232,7 +232,7 @@ class FileAccessor(Accessor):
 
     def writeFile(self, in_fh, out_name):
         logger.info("Copying to %s" % os.path.join(self.baseAddress, out_name))
-        out_fh = open(os.path.join(self.baseAddress, out_name), 'w')
+        out_fh = open(os.path.join(self.baseAddress, out_name), "wb")
         return self._writeFile(in_fh, out_fh)
 
     def __repr__(self):


### PR DESCRIPTION
- [tests/test_mountingaccessor.py: Check MountingAccessor 404 handling](https://github.com/xenserver/python-libs/commit/f3cf25bdd5b32a5e37251735ece75445511dd5f2)

  Test error handling and get coverage for trying to access a nonexisting file

- [tests/test_accessor.py: Update test of FileAccessor](https://github.com/xenserver/python-libs/commit/2a5db65991132030096c187b78cd4ae4c70f8e54)

  Update tests of FileAccessor to verify FileAccessor.writeFile()
- [xcp/accessor.py: Update FileAcessor.writeFile() to support binary files](https://github.com/xenserver/python-libs/commit/46546a1a6525237060f3c8beed84d8aaf34ca962)

  In line with all other Accessor.writeFile() implementations before, use binary mode for writing files as needed to write compressed archives.
