### PR TITLE
xcp.net.ip.ip_link_set_name(): Fix the logged error code when link_up fails

### DIFF
--- a/xcp/net/ip.py
+++ b/xcp/net/ip.py
@@ -97,8 +97,7 @@ def ip_link_set_name(src_name, dst_name):
 
         if link_up.returncode != 0:
             LOG.error("Unable to bring link %s back up. (Exit %d)"
-                      % (src_name, link_down.returncode))
+                      % (src_name, link_up.returncode))  # pragma: no cover
             return
 
     LOG.info("Succesfully renamed link %s to %s" % (src_name, dst_name))
-

--- a/xcp/net/ip.py
+++ b/xcp/net/ip.py
@@ -30,13 +30,13 @@ Python function using 'ip' for convenience
 __version__ = "1.0.1"
 __author__ = "Andrew Cooper"
 
+from os import environ
 from subprocess import Popen, PIPE
 
 from xcp.logger import LOG
 
 # Deal with lack of environment more sensibly than hard coding /sbin/ip
 # which happens to be false in the installer.
-from os import environ
 paths = environ["PATH"].split(":")
 if "/sbin" not in paths:
     environ["PATH"] += ":/sbin"


### PR DESCRIPTION
[xcp/net/ip.py: Fix logged ip exit status when ip up fails](https://github.com/xenserver/python-libs/commit/239cfcb7ff983a7cb4269340d58433ed4c2d7a05)

`ip_link_set_name()`: Fix the logged error code when `link_up` fails:
Log `link_up.returncode` when `link_up` fails, not `link_down.returncode`

When the error handling of "`link_up`" was copied from "`link_down`",
the logged error code should have been updated to `link_down.returncode`.
(Found when looking at pyright/pylance/vscode static analysis messages)