### PR TITLE
cpiofile:  Update method signatures

### DIFF
--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -1120,6 +1120,7 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def xzopen(cls, name, mode="r", fileobj=None, compresslevel=6):
+        # type:(str, Literal["r", "w"], Optional[IO[bytes]], int) -> CpioFile
         """
         Open xz compressed cpio archive name for reading or writing.
         Appending is not allowed.
@@ -1139,7 +1140,7 @@ class CpioFile(six.Iterator):
             kwargs["options"] = {"level": compresslevel}
         elif "w" in mode:
             kwargs["preset"] = compresslevel
-        fileobj = lzma.LZMAFile(name, mode, **kwargs)
+        fileobj = lzma.LZMAFile(name, mode, **cast(Any, kwargs))
         try:
             t = cls.cpioopen(name, mode, fileobj)
         except IOError:

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -55,7 +55,7 @@ import time
 import struct
 import copy
 import io
-from typing import IO, TYPE_CHECKING, Any, cast
+from typing import IO, TYPE_CHECKING, Any, Optional, cast
 
 import six
 
@@ -1070,9 +1070,8 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def cpioopen(cls, name, mode="r", fileobj=None):
-        # type:(str, str, IO[Any] | GzipFile | None) -> CpioFile
-        """Open uncompressed cpio archive name for reading or writing.
-        """
+        # type:(str, str, Optional[GzipFile | IO[Any]]) -> CpioFile
+        """Open uncompressed cpio archive name for reading or writing."""
         if len(mode) > 1 or mode not in "raw":
             raise ValueError("mode must be 'r', 'a' or 'w'")
         return cls(name, mode, fileobj)
@@ -1102,7 +1101,7 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def bz2open(cls, name, mode="r", fileobj=None, compresslevel=9):
-        # type:(str, Literal["r", "w"], IO[Any] | None, int) -> CpioFile
+        # type:(str, Literal["r", "w"], Optional[IO[Any]], int) -> CpioFile
         """Open bzip2 compressed cpio archive name for reading or writing, no appending"""
         if len(mode) > 1 or mode not in "rw":
             raise ValueError("mode must be 'r' or 'w'.")

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -55,7 +55,7 @@ import time
 import struct
 import copy
 import io
-from typing import IO, TYPE_CHECKING, Any, Optional, cast
+from typing import IO, TYPE_CHECKING, Any, List, Optional, cast
 
 import six
 
@@ -951,7 +951,7 @@ class CpioFile(six.Iterator):
 
         # Init datastructures
         self.closed = False
-        self.members = []       # list of members as CpioInfo objects
+        self.members = []       # type:list[CpioInfo]
         self._loaded = False    # flag if all members have been read
         self.offset = 0        # current position in the archive file
         self.inodes = {}        # dictionary caching the inodes of
@@ -1188,6 +1188,7 @@ class CpioFile(six.Iterator):
         return cpioinfo
 
     def getmembers(self):
+        # type:() -> List[CpioInfo]
         """Return the members of the archive as a list of CpioInfo objects. The
            list has the same order as the members in the archive.
         """

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -1070,7 +1070,7 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def cpioopen(cls, name, mode="r", fileobj=None):
-        # type:(str, str, Optional[GzipFile | IO[Any]]) -> CpioFile
+        # type:(str, str, Optional[GzipFile | IO[bytes]]) -> CpioFile
         """Open uncompressed cpio archive name for reading or writing."""
         if len(mode) > 1 or mode not in "raw":
             raise ValueError("mode must be 'r', 'a' or 'w'")
@@ -1101,7 +1101,7 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def bz2open(cls, name, mode="r", fileobj=None, compresslevel=9):
-        # type:(str, Literal["r", "w"], Optional[IO[Any]], int) -> CpioFile
+        # type:(str, Literal["r", "w"], Optional[IO[bytes]], int) -> CpioFile
         """Open bzip2 compressed cpio archive name for reading or writing, no appending"""
         if len(mode) > 1 or mode not in "rw":
             raise ValueError("mode must be 'r' or 'w'.")

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -60,8 +60,8 @@ from typing import IO, TYPE_CHECKING, Any, cast
 import six
 
 if TYPE_CHECKING:
-    from bz2 import _ReadBinaryMode, _WriteBinaryMode
     from gzip import GzipFile
+    from typing_extensions import Literal
 
 if sys.platform == 'mac':
     # This module needs work for MacOS9, especially in the area of pathname
@@ -558,7 +558,7 @@ class _BZ2Proxy(_CMPProxy):
     """
 
     def __init__(self, fileobj, mode):
-        # type:(IO[Any], _ReadBinaryMode | _WriteBinaryMode) -> None
+        # type:(IO[Any], str) -> None
         _CMPProxy.__init__(self, fileobj, mode)
         self.init()
 
@@ -1070,7 +1070,7 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def cpioopen(cls, name, mode="r", fileobj=None):
-        # type:(str, _ReadBinaryMode | _WriteBinaryMode, IO[Any] | GzipFile | None) -> CpioFile
+        # type:(str, str, IO[Any] | GzipFile | None) -> CpioFile
         """Open uncompressed cpio archive name for reading or writing.
         """
         if len(mode) > 1 or mode not in "raw":
@@ -1102,10 +1102,8 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def bz2open(cls, name, mode="r", fileobj=None, compresslevel=9):
-        # type:(str, _ReadBinaryMode | _WriteBinaryMode, IO[Any] | None, int) -> CpioFile
-        """Open bzip2 compressed cpio archive name for reading or writing.
-           Appending is not allowed.
-        """
+        # type:(str, Literal["r", "w"], IO[Any] | None, int) -> CpioFile
+        """Open bzip2 compressed cpio archive name for reading or writing, no appending"""
         if len(mode) > 1 or mode not in "rw":
             raise ValueError("mode must be 'r' or 'w'.")
 


### PR DESCRIPTION
Simple PR only affecting type annotations of `xcp/cpiofile.py`:
- [xcp/cpiofile.py: Fix typing of CpioFile.*open() methods](https://github.com/xenserver/python-libs/pull/79/commits/d14fd23e80a8cb2231695e8b3d1a62ac7de1382a)

  - CpioFile.cpioopen(): `name` is `None` when `fileobj` is passed
  - Change typing from private types of `bz2` to `str` and `Literal`

- [xcp/cpiofile.py: Use Optional[arg] as type for optional arg](https://github.com/xenserver/python-libs/pull/79/commits/4cec27dc1ee60b5ccccb008991e64b71dfaf79c5)
  - Use `Optional[arg]` when arg is optional instead of `arg|None`
    (to be more specific and more clear to read)
- [xcp/cpiofile.py: Make typing fileobj more exact: IO[bytes]](https://github.com/xenserver/python-libs/pull/79/commits/a699eb53dc63c8f904a54e730cb611546c0debd6)
  - Make typing more exact by typing fileobj as IO[bytes]
  
- [xcp/cpiofile.py: Add type annotation to CpioFile.getmembers()](https://github.com/xenserver/python-libs/pull/79/commits/bca496f151e06b28682309b2320ba062bd84bcc9)

  - Add type annotation to `CpioFile.getmembers()` (many other type annotations depend on it)

- [xcp/cpiofile.py: Add type annotation to CpioFile.xzopen()](https://github.com/xenserver/python-libs/pull/79/commits/85382dd603df26c309f5eccc8521cbaf9edb195f)

  - Add method type annotation to `CpioFile.xzopen()` and workaround mypy issue on `lzma.LZMAFile()` needing different kwargs for Python2/Python3