### PR TITLE
xcp/cpiofile.py: Add type signature to CpioFileCompat.__init__()

### DIFF
--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -1120,6 +1120,7 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def xzopen(cls, name, mode="r", fileobj=None, compresslevel=6):
+        # type:(str, Literal["r", "w"], Optional[IO[bytes]], int) -> CpioFile
         """
         Open xz compressed cpio archive name for reading or writing.
         Appending is not allowed.
@@ -1139,7 +1140,7 @@ class CpioFile(six.Iterator):
             kwargs["options"] = {"level": compresslevel}
         elif "w" in mode:
             kwargs["preset"] = compresslevel
-        fileobj = lzma.LZMAFile(name, mode, **kwargs)
+        fileobj = lzma.LZMAFile(name, mode, **cast(Any, kwargs))
         try:
             t = cls.cpioopen(name, mode, fileobj)
         except IOError:

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -55,7 +55,7 @@ import time
 import struct
 import copy
 import io
-from typing import IO, TYPE_CHECKING, Any, cast
+from typing import IO, TYPE_CHECKING, Any, Optional, cast
 
 import six
 
@@ -1070,9 +1070,8 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def cpioopen(cls, name, mode="r", fileobj=None):
-        # type:(str, str, IO[Any] | GzipFile | None) -> CpioFile
-        """Open uncompressed cpio archive name for reading or writing.
-        """
+        # type:(str, str, Optional[GzipFile | IO[Any]]) -> CpioFile
+        """Open uncompressed cpio archive name for reading or writing."""
         if len(mode) > 1 or mode not in "raw":
             raise ValueError("mode must be 'r', 'a' or 'w'")
         return cls(name, mode, fileobj)
@@ -1102,7 +1101,7 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def bz2open(cls, name, mode="r", fileobj=None, compresslevel=9):
-        # type:(str, Literal["r", "w"], IO[Any] | None, int) -> CpioFile
+        # type:(str, Literal["r", "w"], Optional[IO[Any]], int) -> CpioFile
         """Open bzip2 compressed cpio archive name for reading or writing, no appending"""
         if len(mode) > 1 or mode not in "rw":
             raise ValueError("mode must be 'r' or 'w'.")

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -55,7 +55,7 @@ import time
 import struct
 import copy
 import io
-from typing import IO, TYPE_CHECKING, Any, Optional, cast
+from typing import IO, TYPE_CHECKING, Any, List, Optional, cast
 
 import six
 
@@ -951,7 +951,7 @@ class CpioFile(six.Iterator):
 
         # Init datastructures
         self.closed = False
-        self.members = []       # list of members as CpioInfo objects
+        self.members = []       # type:list[CpioInfo]
         self._loaded = False    # flag if all members have been read
         self.offset = 0        # current position in the archive file
         self.inodes = {}        # dictionary caching the inodes of
@@ -1188,6 +1188,7 @@ class CpioFile(six.Iterator):
         return cpioinfo
 
     def getmembers(self):
+        # type:() -> List[CpioInfo]
         """Return the members of the archive as a list of CpioInfo objects. The
            list has the same order as the members in the archive.
         """

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -1762,6 +1762,7 @@ class CpioFile(six.Iterator):
         return cpioinfo
 
     def _getmember(self, name, cpioinfo=None):
+        # type:(str | bytes, CpioInfo | None) -> CpioInfo | None
         """Find an archive member by name from bottom to top.
            If cpioinfo is given, it is used as the starting point.
         """
@@ -1777,6 +1778,7 @@ class CpioFile(six.Iterator):
         for i in range(end - 1, -1, -1):
             if encoded_name == members[i].name:
                 return members[i]
+        return None  # pragma: no cover
 
     def _load(self):
         """Read through the entire archive file and look for readable

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -37,6 +37,8 @@
    Derived from Lars Gustäbel's tarfile.py
 """
 from __future__ import print_function
+# pyre is not as good as other static analysis tools in inferring the correct types:
+# pyre-ignore-all-errors[6,16]
 
 __version__ = "0.1"
 __author__  = "Simon Rowe"
@@ -1178,6 +1180,7 @@ class CpioFile(six.Iterator):
         self.closed = True
 
     def getmember(self, name):
+        # type:(str | bytes) -> CpioInfo
         """Return a CpioInfo object for member `name'. If `name' can not be
            found in the archive, KeyError is raised. If a member occurs more
            than once in the archive, its last occurence is assumed to be the
@@ -1457,6 +1460,7 @@ class CpioFile(six.Iterator):
                 self._dbg(1, "cpiofile: %s" % e)
 
     def extractfile(self, member):
+        # type:(CpioInfo) -> ExFileObject | None
         """Extract a member from the archive as a file object. `member' may be
            a filename or a CpioInfo object. If `member' is a regular file, a
            file-like object is returned. If `member' is a link, a file-like
@@ -1486,7 +1490,7 @@ class CpioFile(six.Iterator):
             else:
                 # A symlink's file object is its target's file object.
                 return self.extractfile(self._getmember(cpioinfo.linkname,
-                                                        cpioinfo))
+                                                        cpioinfo))  # type: ignore
         else:
             # If there's no data associated with the member (directory, chrdev,
             # blkdev, etc.), return None instead of a file object.

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -1070,7 +1070,7 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def cpioopen(cls, name, mode="r", fileobj=None):
-        # type:(str, str, Optional[GzipFile | IO[Any]]) -> CpioFile
+        # type:(str, str, Optional[GzipFile | IO[bytes]]) -> CpioFile
         """Open uncompressed cpio archive name for reading or writing."""
         if len(mode) > 1 or mode not in "raw":
             raise ValueError("mode must be 'r', 'a' or 'w'")
@@ -1101,7 +1101,7 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def bz2open(cls, name, mode="r", fileobj=None, compresslevel=9):
-        # type:(str, Literal["r", "w"], Optional[IO[Any]], int) -> CpioFile
+        # type:(str, Literal["r", "w"], Optional[IO[bytes]], int) -> CpioFile
         """Open bzip2 compressed cpio archive name for reading or writing, no appending"""
         if len(mode) > 1 or mode not in "rw":
             raise ValueError("mode must be 'r' or 'w'.")

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -60,8 +60,8 @@ from typing import IO, TYPE_CHECKING, Any, cast
 import six
 
 if TYPE_CHECKING:
-    from bz2 import _ReadBinaryMode, _WriteBinaryMode
     from gzip import GzipFile
+    from typing_extensions import Literal
 
 if sys.platform == 'mac':
     # This module needs work for MacOS9, especially in the area of pathname
@@ -558,7 +558,7 @@ class _BZ2Proxy(_CMPProxy):
     """
 
     def __init__(self, fileobj, mode):
-        # type:(IO[Any], _ReadBinaryMode | _WriteBinaryMode) -> None
+        # type:(IO[Any], str) -> None
         _CMPProxy.__init__(self, fileobj, mode)
         self.init()
 
@@ -1070,7 +1070,7 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def cpioopen(cls, name, mode="r", fileobj=None):
-        # type:(str, _ReadBinaryMode | _WriteBinaryMode, IO[Any] | GzipFile | None) -> CpioFile
+        # type:(str, str, IO[Any] | GzipFile | None) -> CpioFile
         """Open uncompressed cpio archive name for reading or writing.
         """
         if len(mode) > 1 or mode not in "raw":
@@ -1102,10 +1102,8 @@ class CpioFile(six.Iterator):
 
     @classmethod
     def bz2open(cls, name, mode="r", fileobj=None, compresslevel=9):
-        # type:(str, _ReadBinaryMode | _WriteBinaryMode, IO[Any] | None, int) -> CpioFile
-        """Open bzip2 compressed cpio archive name for reading or writing.
-           Appending is not allowed.
-        """
+        # type:(str, Literal["r", "w"], IO[Any] | None, int) -> CpioFile
+        """Open bzip2 compressed cpio archive name for reading or writing, no appending"""
         if len(mode) > 1 or mode not in "rw":
             raise ValueError("mode must be 'r' or 'w'.")
 

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -1858,18 +1858,13 @@ class CpioFileCompat(object):
        ZipFile class.
     """
     def __init__(self, fpath, mode="r", compression=CPIO_PLAIN):
+        # type:(str, Literal["r", "w"], int) -> None
         if compression == CPIO_PLAIN:
             self.cpiofile = CpioFile.cpioopen(fpath, mode)
         elif compression == CPIO_GZIPPED:
             self.cpiofile = CpioFile.gzopen(fpath, mode)
         else:
             raise ValueError("unknown compression constant")
-        if mode[0:1] == "r":
-            members = self.cpiofile.getmembers()
-            for m in members:
-                m.filename = m.name
-                m.file_size = m.size
-                m.date_time = time.gmtime(m.mtime)[:6]
     def namelist(self):
         return [m.name for m in self.infolist()]
     def infolist(self):


### PR DESCRIPTION
Please review #83 before this PR (the first 5 commits are from it).

The remaining commits are:

- [xcp/cpiofile.py: Add type signature to `CpioFileCompat.__init__()`](https://github.com/xenserver/python-libs/pull/83/commits/3a491647f44870e6adce231bb2da8d14e8e3b0c4)

  - Add type signature to `CpioFileCompat.__init__()`
  - Cleanup setting member variables which are never red
    (e.g. CpioInfo.name has the inode name, not .filename, etc)

- [xcp/cpiofile.py: Add type signature to _getmember()](https://github.com/xenserver/python-libs/pull/83/commits/a79d2211dd6a148c6beb8a85ff3dcf381da6d56b)

  - add type signature
  - add missing default return (required by `mypy`)

- [xcp/cpiofile.py: Add type signature to getmember(), extractfile()](https://github.com/xenserver/python-libs/pull/83/commits/3992d0387359948d77d18484321d128064d7e3f1)

  - Add type signature to `CpioFile.extractfile()` and `.getmember()`