### PR TITLE
Cpio fix symlink handling

### DIFF
--- a/tests/test_cpio.py
+++ b/tests/test_cpio.py
@@ -80,6 +80,7 @@ class TestCpio(unittest.TestCase):
             assert cpio_header[:100] == xcp.cpiofile.CpioInfo.frombuf(cpio_header).tobuf()[:100]
 
             if f.isfile():
+                assert f.name == b"archive/data"
                 data = arc.extractfile(f).read()
                 self.assertEqual(len(data), f.size)
                 self.assertEqual(self.md5data, md5(data).hexdigest())

--- a/tests/test_cpio.py
+++ b/tests/test_cpio.py
@@ -70,6 +70,13 @@ class TestCpio(unittest.TestCase):
         arc = CpioFile.open(fn, fmt)
         found = False
         for f in arc:
+            # Cover CpioInfo.frombuf() and .tobuf():
+            f.linkname = "test_linkname_tobuf"
+            cpio_header = f.tobuf()
+
+            # CpioInfo.frombuf() returns a CpioInfo obj but does not set names from the header:
+            assert cpio_header[:100] == xcp.cpiofile.CpioInfo.frombuf(cpio_header).tobuf()[:100]
+
             if f.isfile():
                 data = arc.extractfile(f).read()
                 self.assertEqual(len(data), f.size)

--- a/tests/test_cpio.py
+++ b/tests/test_cpio.py
@@ -42,7 +42,9 @@ class TestCpio(unittest.TestCase):
         writeRandomFile('archive/data', 10491)
         with open('archive/data', 'rb') as fd:
             self.md5data = md5(fd.read()).hexdigest()
+        os.symlink("data", "archive/linkname")
         # fixed timestamps for cpio reproducibility
+        os.utime('archive/linkname', (0, 0))
         os.utime('archive/data', (0, 0))
         os.utime('archive', (0, 0))
 
@@ -167,6 +169,7 @@ class TestCpio(unittest.TestCase):
         arc = CpioFileCompat(fn, mode="w", compression={"": CPIO_PLAIN,
                                                         "gz": CPIO_GZIPPED}[comp])
         arc.write('archive/data')
+        arc.write('archive/linkname')
         arc.close()
         self.archiveExtract(fn)
 

--- a/tests/test_cpio.py
+++ b/tests/test_cpio.py
@@ -96,12 +96,9 @@ class TestCpio(unittest.TestCase):
         if os.path.exists(fn):
             os.unlink(fn)
         arc = CpioFile.open(fn, fmt)
-        f = arc.getcpioinfo('archive/data')
-        with open('archive/data', 'rb') as fd:
-            arc.addfile(f, fd)
-        # test recursively add "."
+        # Recursively add "." as directory "archive"
         os.chdir('archive')
-        arc.add(".")
+        arc.add(".", "archive")
         os.chdir("..")
         # TODO add self crafted file
         arc.close()

--- a/tests/test_cpiofile.py
+++ b/tests/test_cpiofile.py
@@ -1,0 +1,131 @@
+"""
+Test various modes of creating and extracting CpioFile using different compression
+types, opening the archive as stream and as file, using pyfakefs as filesystem without
+ever touching any real real file. pyfakefs was developed by Google and is in wide use.
+https://pytest-pyfakefs.readthedocs.io/en/latest/intro.html
+"""
+import io
+import os
+import sys
+from typing import cast
+
+import pytest
+from pyfakefs.fake_filesystem import FakeFileOpen, FakeFilesystem
+
+from xcp.cpiofile import CpioFile
+
+from .test_mountingaccessor import binary_data
+
+
+def test_cpiofile_modes(fs):
+    # type: (FakeFilesystem) -> None
+    """
+    Test various modes of creating and extracting CpioFile using different compression
+    types, opening the archive as stream and as file.
+
+    :param fs: `FakeFilesystem` fixture representing a simulated file system for testing
+    """
+    with pytest.raises(TypeError) as exc_info:
+        CpioFile.open(fileobj=io.StringIO())  # type: ignore[arg-type]
+    assert exc_info.type == TypeError
+    if sys.version_info < (3, 0):
+        # Test Python2 pattern from host-upgrade-plugin:/etc/xapi.d/plugins/prepare_host_upgrade.py
+        import StringIO
+
+        stringio = StringIO.StringIO()
+        archive = CpioFile.open(fileobj=stringio, mode="w|gz")  # type: ignore[arg-type]
+        archive.hardlinks = False
+        archive.close()
+        stringio.seek(0)
+        assert stringio.read()
+
+    for comp in ["cpio", "gz", "bz2", "xz"]:
+        for filetype in [":", "|"]:
+            if comp == "xz" and filetype == ":":
+                continue  # streaming xz is not implemented (supported only as file)
+            check_archive_mode(filetype + comp, fs)
+
+
+def check_archive_mode(archive_mode, fs):
+    # type: (str, FakeFilesystem) -> None
+    """
+    Test CpioFile in the given archive mode with verification of the archive contents.
+
+    :param archive_mode: The archive mode is a string parameter that specifies the mode
+    in which the CpioFile object should be opened.
+    :param fs: `FakeFilesystem` fixture representing a simulated file system for testing
+    """
+    # Step 1: Create and populate a cpio archive in a BytesIO buffer
+    bytesio = io.BytesIO()
+    archive = CpioFile.open(fileobj=bytesio, mode="w" + archive_mode)
+    pyfakefs_populate_archive(archive, fs)
+    if archive_mode == "|gz":
+        archive.list(verbose=True)
+    archive.close()
+
+    # Step 2: Extract the archive in a clean filesystem and verify the extracted contents
+    fs.reset()
+    bytesio.seek(0)
+    archive = CpioFile.open(fileobj=bytesio, mode="r" + archive_mode)
+    archive.extractall()
+    pyfakefs_verify_filesystem(fs)
+    assert archive.getnames() == [b"dirname", b"dirname/filename", b"dir2/symlink"]
+    dirs = [cpioinfo.name for cpioinfo in archive.getmembers() if cpioinfo.isdir()]
+    files = [cpioinfo.name for cpioinfo in archive.getmembers() if cpioinfo.isreg()]
+    symlinks = [cpioinfo.name for cpioinfo in archive.getmembers() if cpioinfo.issym()]
+    assert dirs == [b"dirname"]
+    assert files == [b"dirname/filename"]
+    assert symlinks == [b"dir2/symlink"]
+    assert archive.getmember(symlinks[0]).linkname == "symlink_target"
+    archive.close()
+
+    # Step 3: Extract the archive a second time using another method
+    fs.reset()
+    bytesio.seek(0)
+    archive = CpioFile.open(fileobj=bytesio, mode="r" + archive_mode)
+    if archive_mode[0] != "|":
+        for cpioinfo in archive:
+            archive.extract(cpioinfo)
+        pyfakefs_verify_filesystem(fs)
+    if archive_mode == "|xz":
+        archive.list(verbose=True)
+    archive.close()
+    bytesio.close()
+
+
+def pyfakefs_populate_archive(archive, fs):
+    # type: (CpioFile, FakeFilesystem) -> None
+    """
+    Populate a CpioFile archive with files and directories from a FakeFilesystem.
+
+    :param archive: Instance of the CpioFile class to create a new cpio archive
+    :param fs: `FakeFilesystem` fixture representing a simulated file system for testing
+    """
+    fs.reset()
+
+    fs.create_file("dirname/filename", contents=cast(str, binary_data))
+    archive.add("dirname", recursive=True)
+    fs.create_symlink("directory/symlink", "symlink_target")
+
+    # Test special code path of archive.add(".", ...):
+    os.chdir("directory")
+    archive.add(".", "dir2", recursive=True)  # Test adding . as dir2
+    os.chdir("..")
+    os.rename("directory", "dir2")
+
+    pyfakefs_verify_filesystem(fs)
+
+
+def pyfakefs_verify_filesystem(fs):
+    # type: (FakeFilesystem) -> None
+    """
+    Verify the contents of the fake filesystem populated by pyfakefs_populate_archive()
+    and it is called again after a CpioFile.extractall() extracted the populated files
+    from the cpio archive.
+
+    :param fs: `FakeFilesystem` fixture representing a simulated file system for testing
+    """
+    assert fs.islink("dir2/symlink")
+    assert fs.isfile("dirname/filename")
+    with FakeFileOpen(fs)("dirname/filename", "rb") as contents:
+        assert contents.read() == binary_data

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -846,8 +846,7 @@ class CpioInfo(object):
         return cpioinfo
 
     def tobuf(self):
-        """Return a cpio header as a string.
-        """
+        """Return a cpio header as bytes"""
         buf = b"%06X" % MAGIC_NEWC
         buf += b"%08X" % self.ino
         buf += b"%08X" % self.mode
@@ -871,7 +870,7 @@ class CpioInfo(object):
             buf += (WORDSIZE - remainder) * NUL
 
         if self.linkname != '':
-            buf += self.linkname
+            buf += six.ensure_binary(self.linkname)
             _, remainder = divmod(len(buf), WORDSIZE)
             if remainder != 0:
                 # pad to next word
@@ -1712,7 +1711,7 @@ class CpioFile(six.Iterator):
 
             if cpioinfo.issym():
                 linkname_buf = self.fileobj.read(self._word(cpioinfo.size))
-                cpioinfo.linkname = linkname_buf.rstrip(NUL)
+                cpioinfo.linkname = six.ensure_text(linkname_buf.rstrip(NUL))
                 self.offset += self._word(cpioinfo.size)
                 cpioinfo.size = 0
 

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -1021,6 +1021,13 @@ class CpioFile(six.Iterator):
 
         if not name and not fileobj:
             raise ValueError("nothing to open")
+        if fileobj:
+            if sys.version_info < (3, 0):
+                if isinstance(fileobj, io.StringIO):
+                    raise TypeError("CpioFile.fileobj does not support io.StringIO()")
+            else:
+                if not isinstance(fileobj, io.IOBase) or isinstance(fileobj, io.TextIOBase):
+                    raise TypeError("CpioFile.fileobj needs to be IO[bytes] or io.BytesIO()")
 
         if mode in ("r", "r:*"):
             # Find out which *open() is appropriate for opening the file.

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -545,7 +545,8 @@ class _CMPProxy(object):
         if self.mode == "w":
             raw = self.cmpobj.flush()
             self.fileobj.write(raw)
-        self.fileobj.close()
+        if not isinstance(self.fileobj, io.BytesIO):  # BytesIO() would free the archive on close()
+            self.fileobj.close()
 # class _CMPProxy
 
 


### PR DESCRIPTION
- [tests/test_cpio.py: Cover CpioInfo.frombuf() and .tobuf()](https://github.com/xenserver/python-libs/commit/1d5053ef81548504fcb3986eabac28cd900bb8f5)
  Cover fixes in CpioInfo.frombuf() and .tobuf() with .linkname
- [tests/test_cpio.py: Fix test archive creation to be as expected](https://github.com/xenserver/python-libs/commit/13df86d9bb163692c8fa29db9f33c6e79a22d2bb)
  Fix to not add "archive/data" twice to the test archive
- [tests/test_cpio.py: Add a symbolic link to the test archives](https://github.com/xenserver/python-libs/commit/4b1a0d6949fb7bf4b0a463c04a737d0e688b6153)
  To test symlink handling in xcp.cpiofile, add a symbolic link to the test archives
- [xcp/cpiofile.py: Fix linkname handling in CpioInfo](https://github.com/xenserver/python-libs/commit/2ac47cfac428f94357c266adb87ff05e5cd84688)
  CpioInfo.linkname is required to be a string in multiple methods of CpioInfo, and in two places a conversion needs to happen:
  - In CpioInfo.tobuf():
    Fix a case of bytes += str (appending str to bytes is not possible) when CpioInfo.linkname is set in CpioInfo.tobuf()
  - In CpioInfo.__next__():
    Then cpioinfo.issym() is True, cpio.linkname is set from the buffer which is read as bytes, so at this place, ensure conversion to str.
- [xcp/cpiofile.py: CpioInfo.open() check fileobj type](https://github.com/xenserver/python-libs/commit/a49f9ebe1dc0c8e5e374da4b976ea8ca833a65d0)
  host-upgrade-plugin:/etc/xapi.d/plugins/prepare_host_upgrade.py calls cpiofile.CpioFile.open(fileobj=StringIO()) which does not work for Py3:
  Raise as helpful exception for updating host-upgrade-plugin accordingly: Raise an TypeError if fileobj is io.StringIO() (for Python2, it requires unicode) and if Python3, is a subclass of IO[bytes], not IO[str].
- [xcp/cpiofile.py: _BZ2Proxy.close(): Keep fileobj if instance of io.BytesIO](https://github.com/xenserver/python-libs/commit/5e3d2f1288143cb48b2be3f84288bf793b45adc5)
  In for bz2 in-memory streams, add that the in-memory bytes stream from BytesIO is not freed by not calling BytesIO.close() from _BZ2Proxy.close() Explanation:
  - Transparent compression to and from bz2 streams is handled thru _BZ2Proxy
  - When using the pattern used by host-upgrade-plugin, it _BZ2Proxy close the BytesIO buffer which frees the cpio archive from memory after the cpio archive is completed, so the created archive could not be red.
  - This would prevent this pattern to be used by host-upgrade-plugin and tests, so add a case that the in-memory bytes stream BytesIO is not claosed by _BZ2Proxy.close().
- [tests/test_cpio.py: Add checking the CpioInfo.name field](https://github.com/xenserver/python-libs/commit/0fe847b08ee9e573775f78b357fffeb710c66f37)
  Add a check of CpioInfo.name for the file "archive/data".
- [tests/test_cpiofile.py: Add new tests for xcp.cpiofile](https://github.com/xenserver/python-libs/commit/785a708dfce24a838c83d590d0a1b5d0ef08b31a)
  To cover changed methods/lines add testcases for xcp.cpiofile: Test various modes of creating and extracting CpioFile using different compression types, opening the archive as stream and as file.  