### PR TITLE
xcp/cpiofile.py: Fix pyright warnings in the _CMPProxy class

### DIFF
--- a/tests/test_cpio.py
+++ b/tests/test_cpio.py
@@ -80,6 +80,7 @@ class TestCpio(unittest.TestCase):
             assert cpio_header[:100] == xcp.cpiofile.CpioInfo.frombuf(cpio_header).tobuf()[:100]
 
             if f.isfile():
+                assert f.name == b"archive/data"
                 data = arc.extractfile(f).read()
                 self.assertEqual(len(data), f.size)
                 self.assertEqual(self.md5data, md5(data).hexdigest())

--- a/tests/test_cpio.py
+++ b/tests/test_cpio.py
@@ -70,6 +70,13 @@ class TestCpio(unittest.TestCase):
         arc = CpioFile.open(fn, fmt)
         found = False
         for f in arc:
+            # Cover CpioInfo.frombuf() and .tobuf():
+            f.linkname = "test_linkname_tobuf"
+            cpio_header = f.tobuf()
+
+            # CpioInfo.frombuf() returns a CpioInfo obj but does not set names from the header:
+            assert cpio_header[:100] == xcp.cpiofile.CpioInfo.frombuf(cpio_header).tobuf()[:100]
+
             if f.isfile():
                 data = arc.extractfile(f).read()
                 self.assertEqual(len(data), f.size)

--- a/tests/test_cpio.py
+++ b/tests/test_cpio.py
@@ -42,7 +42,9 @@ class TestCpio(unittest.TestCase):
         writeRandomFile('archive/data', 10491)
         with open('archive/data', 'rb') as fd:
             self.md5data = md5(fd.read()).hexdigest()
+        os.symlink("data", "archive/linkname")
         # fixed timestamps for cpio reproducibility
+        os.utime('archive/linkname', (0, 0))
         os.utime('archive/data', (0, 0))
         os.utime('archive', (0, 0))
 
@@ -167,6 +169,7 @@ class TestCpio(unittest.TestCase):
         arc = CpioFileCompat(fn, mode="w", compression={"": CPIO_PLAIN,
                                                         "gz": CPIO_GZIPPED}[comp])
         arc.write('archive/data')
+        arc.write('archive/linkname')
         arc.close()
         self.archiveExtract(fn)
 

--- a/tests/test_cpio.py
+++ b/tests/test_cpio.py
@@ -80,7 +80,7 @@ class TestCpio(unittest.TestCase):
             assert cpio_header[:100] == xcp.cpiofile.CpioInfo.frombuf(cpio_header).tobuf()[:100]
 
             if f.isfile():
-                assert f.name == b"archive/data"
+                assert f.name == "archive/data"
                 data = arc.extractfile(f).read()
                 self.assertEqual(len(data), f.size)
                 self.assertEqual(self.md5data, md5(data).hexdigest())

--- a/tests/test_cpio.py
+++ b/tests/test_cpio.py
@@ -96,12 +96,9 @@ class TestCpio(unittest.TestCase):
         if os.path.exists(fn):
             os.unlink(fn)
         arc = CpioFile.open(fn, fmt)
-        f = arc.getcpioinfo('archive/data')
-        with open('archive/data', 'rb') as fd:
-            arc.addfile(f, fd)
-        # test recursively add "."
+        # Recursively add "." as directory "archive"
         os.chdir('archive')
-        arc.add(".")
+        arc.add(".", "archive")
         os.chdir("..")
         # TODO add self crafted file
         arc.close()

--- a/tests/test_cpiofile.py
+++ b/tests/test_cpiofile.py
@@ -69,13 +69,13 @@ def check_archive_mode(archive_mode, fs):
     archive = CpioFile.open(fileobj=bytesio, mode="r" + archive_mode)
     archive.extractall()
     pyfakefs_verify_filesystem(fs)
-    assert archive.getnames() == [b"dirname", b"dirname/filename", b"dir2/symlink"]
+    assert archive.getnames() == ["dirname", "dirname/filename", "dir2/symlink"]
     dirs = [cpioinfo.name for cpioinfo in archive.getmembers() if cpioinfo.isdir()]
     files = [cpioinfo.name for cpioinfo in archive.getmembers() if cpioinfo.isreg()]
     symlinks = [cpioinfo.name for cpioinfo in archive.getmembers() if cpioinfo.issym()]
-    assert dirs == [b"dirname"]
-    assert files == [b"dirname/filename"]
-    assert symlinks == [b"dir2/symlink"]
+    assert dirs == ["dirname"]
+    assert files == ["dirname/filename"]
+    assert symlinks == ["dir2/symlink"]
     assert archive.getmember(symlinks[0]).linkname == "symlink_target"
     archive.close()
 

--- a/tests/test_cpiofile.py
+++ b/tests/test_cpiofile.py
@@ -1,0 +1,131 @@
+"""
+Test various modes of creating and extracting CpioFile using different compression
+types, opening the archive as stream and as file, using pyfakefs as filesystem without
+ever touching any real real file. pyfakefs was developed by Google and is in wide use.
+https://pytest-pyfakefs.readthedocs.io/en/latest/intro.html
+"""
+import io
+import os
+import sys
+from typing import cast
+
+import pytest
+from pyfakefs.fake_filesystem import FakeFileOpen, FakeFilesystem
+
+from xcp.cpiofile import CpioFile
+
+from .test_mountingaccessor import binary_data
+
+
+def test_cpiofile_modes(fs):
+    # type: (FakeFilesystem) -> None
+    """
+    Test various modes of creating and extracting CpioFile using different compression
+    types, opening the archive as stream and as file.
+
+    :param fs: `FakeFilesystem` fixture representing a simulated file system for testing
+    """
+    with pytest.raises(TypeError) as exc_info:
+        CpioFile.open(fileobj=io.StringIO())  # type: ignore[arg-type]
+    assert exc_info.type == TypeError
+    if sys.version_info < (3, 0):
+        # Test Python2 pattern from host-upgrade-plugin:/etc/xapi.d/plugins/prepare_host_upgrade.py
+        import StringIO
+
+        stringio = StringIO.StringIO()
+        archive = CpioFile.open(fileobj=stringio, mode="w|gz")  # type: ignore[arg-type]
+        archive.hardlinks = False
+        archive.close()
+        stringio.seek(0)
+        assert stringio.read()
+
+    for comp in ["cpio", "gz", "bz2", "xz"]:
+        for filetype in [":", "|"]:
+            if comp == "xz" and filetype == ":":
+                continue  # streaming xz is not implemented (supported only as file)
+            check_archive_mode(filetype + comp, fs)
+
+
+def check_archive_mode(archive_mode, fs):
+    # type: (str, FakeFilesystem) -> None
+    """
+    Test CpioFile in the given archive mode with verification of the archive contents.
+
+    :param archive_mode: The archive mode is a string parameter that specifies the mode
+    in which the CpioFile object should be opened.
+    :param fs: `FakeFilesystem` fixture representing a simulated file system for testing
+    """
+    # Step 1: Create and populate a cpio archive in a BytesIO buffer
+    bytesio = io.BytesIO()
+    archive = CpioFile.open(fileobj=bytesio, mode="w" + archive_mode)
+    pyfakefs_populate_archive(archive, fs)
+    if archive_mode == "|gz":
+        archive.list(verbose=True)
+    archive.close()
+
+    # Step 2: Extract the archive in a clean filesystem and verify the extracted contents
+    fs.reset()
+    bytesio.seek(0)
+    archive = CpioFile.open(fileobj=bytesio, mode="r" + archive_mode)
+    archive.extractall()
+    pyfakefs_verify_filesystem(fs)
+    assert archive.getnames() == [b"dirname", b"dirname/filename", b"dir2/symlink"]
+    dirs = [cpioinfo.name for cpioinfo in archive.getmembers() if cpioinfo.isdir()]
+    files = [cpioinfo.name for cpioinfo in archive.getmembers() if cpioinfo.isreg()]
+    symlinks = [cpioinfo.name for cpioinfo in archive.getmembers() if cpioinfo.issym()]
+    assert dirs == [b"dirname"]
+    assert files == [b"dirname/filename"]
+    assert symlinks == [b"dir2/symlink"]
+    assert archive.getmember(symlinks[0]).linkname == "symlink_target"
+    archive.close()
+
+    # Step 3: Extract the archive a second time using another method
+    fs.reset()
+    bytesio.seek(0)
+    archive = CpioFile.open(fileobj=bytesio, mode="r" + archive_mode)
+    if archive_mode[0] != "|":
+        for cpioinfo in archive:
+            archive.extract(cpioinfo)
+        pyfakefs_verify_filesystem(fs)
+    if archive_mode == "|xz":
+        archive.list(verbose=True)
+    archive.close()
+    bytesio.close()
+
+
+def pyfakefs_populate_archive(archive, fs):
+    # type: (CpioFile, FakeFilesystem) -> None
+    """
+    Populate a CpioFile archive with files and directories from a FakeFilesystem.
+
+    :param archive: Instance of the CpioFile class to create a new cpio archive
+    :param fs: `FakeFilesystem` fixture representing a simulated file system for testing
+    """
+    fs.reset()
+
+    fs.create_file("dirname/filename", contents=cast(str, binary_data))
+    archive.add("dirname", recursive=True)
+    fs.create_symlink("directory/symlink", "symlink_target")
+
+    # Test special code path of archive.add(".", ...):
+    os.chdir("directory")
+    archive.add(".", "dir2", recursive=True)  # Test adding . as dir2
+    os.chdir("..")
+    os.rename("directory", "dir2")
+
+    pyfakefs_verify_filesystem(fs)
+
+
+def pyfakefs_verify_filesystem(fs):
+    # type: (FakeFilesystem) -> None
+    """
+    Verify the contents of the fake filesystem populated by pyfakefs_populate_archive()
+    and it is called again after a CpioFile.extractall() extracted the populated files
+    from the cpio archive.
+
+    :param fs: `FakeFilesystem` fixture representing a simulated file system for testing
+    """
+    assert fs.islink("dir2/symlink")
+    assert fs.isfile("dirname/filename")
+    with FakeFileOpen(fs)("dirname/filename", "rb") as contents:
+        assert contents.read() == binary_data

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -1273,7 +1273,7 @@ class CpioFile(six.Iterator):
         if stat.S_ISLNK(stmd):
             cpioinfo.linkname = os.readlink(name)
         cpioinfo.namesize = len(arcname)
-        cpioinfo.name = arcname
+        cpioinfo.name = six.ensure_str(arcname)
 
         return cpioinfo
 
@@ -1705,11 +1705,12 @@ class CpioFile(six.Iterator):
             cpioinfo = CpioInfo.frombuf(buf)
             total_header_len = self._word(HEADERSIZE_SVR4 + cpioinfo.namesize)
             name_buf = self.fileobj.read(total_header_len - HEADERSIZE_SVR4)
-            cpioinfo.name = name_buf.rstrip(NUL)
+            name = name_buf.rstrip(NUL)
 
-            if cpioinfo.name == TRAILER_NAME:
+            if name == TRAILER_NAME:
                 self.offset += total_header_len
                 return None
+            cpioinfo.name = six.ensure_str(name)
 
             # Set the CpioInfo object's offset to the current position of the
             # CpioFile and set self.offset to the position where the data blocks
@@ -1781,7 +1782,7 @@ class CpioFile(six.Iterator):
         else:
             end = members.index(cpioinfo)
 
-        encoded_name = six.ensure_binary(name)
+        encoded_name = six.ensure_str(name)
         for i in range(end - 1, -1, -1):
             if encoded_name == members[i].name:
                 return members[i]

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -503,8 +503,8 @@ class _CMPProxy(object):
         self.fileobj = fileobj
         self.mode = mode
         self.cmpobj = None
-        self.buf = None
-        self.pos = None
+        self.buf = b""
+        self.pos = 0
 
     def read(self, size):
         b = [self.buf]
@@ -512,6 +512,7 @@ class _CMPProxy(object):
         while x < size:
             try:
                 raw = self.fileobj.read(self.blocksize)
+                assert self.cmpobj
                 data = self.cmpobj.decompress(raw)
                 b.append(data)
             except EOFError:
@@ -538,11 +539,13 @@ class _CMPProxy(object):
 
     def write(self, data):
         self.pos += len(data)
+        assert self.cmpobj
         raw = self.cmpobj.compress(data)
         self.fileobj.write(raw)
 
     def close(self):
         if self.mode == "w":
+            assert self.cmpobj
             raw = self.cmpobj.flush()
             self.fileobj.write(raw)
         if not isinstance(self.fileobj, io.BytesIO):  # BytesIO() would free the archive on close()

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -846,8 +846,7 @@ class CpioInfo(object):
         return cpioinfo
 
     def tobuf(self):
-        """Return a cpio header as a string.
-        """
+        """Return a cpio header as bytes"""
         buf = b"%06X" % MAGIC_NEWC
         buf += b"%08X" % self.ino
         buf += b"%08X" % self.mode
@@ -871,7 +870,7 @@ class CpioInfo(object):
             buf += (WORDSIZE - remainder) * NUL
 
         if self.linkname != '':
-            buf += self.linkname
+            buf += six.ensure_binary(self.linkname)
             _, remainder = divmod(len(buf), WORDSIZE)
             if remainder != 0:
                 # pad to next word
@@ -1712,7 +1711,7 @@ class CpioFile(six.Iterator):
 
             if cpioinfo.issym():
                 linkname_buf = self.fileobj.read(self._word(cpioinfo.size))
-                cpioinfo.linkname = linkname_buf.rstrip(NUL)
+                cpioinfo.linkname = six.ensure_text(linkname_buf.rstrip(NUL))
                 self.offset += self._word(cpioinfo.size)
                 cpioinfo.size = 0
 

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -1021,6 +1021,13 @@ class CpioFile(six.Iterator):
 
         if not name and not fileobj:
             raise ValueError("nothing to open")
+        if fileobj:
+            if sys.version_info < (3, 0):
+                if isinstance(fileobj, io.StringIO):
+                    raise TypeError("CpioFile.fileobj does not support io.StringIO()")
+            else:
+                if not isinstance(fileobj, io.IOBase) or isinstance(fileobj, io.TextIOBase):
+                    raise TypeError("CpioFile.fileobj needs to be IO[bytes] or io.BytesIO()")
 
         if mode in ("r", "r:*"):
             # Find out which *open() is appropriate for opening the file.

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -545,7 +545,8 @@ class _CMPProxy(object):
         if self.mode == "w":
             raw = self.cmpobj.flush()
             self.fileobj.write(raw)
-        self.fileobj.close()
+        if not isinstance(self.fileobj, io.BytesIO):  # BytesIO() would free the archive on close()
+            self.fileobj.close()
 # class _CMPProxy
 
 


### PR DESCRIPTION
On top of #84 (9 commits - review it first - they are here to have better code coverage):
* add one commit:
   * Fix pyright warnings in the _CMPProxy class