### PR TITLE
pylint for repository: Fix Unnecessary parens, dom0: unit in ("k", '')

### DIFF
--- a/tests/test_cpio.py
+++ b/tests/test_cpio.py
@@ -53,11 +53,9 @@ class TestCpio(unittest.TestCase):
         check_call("gzip -c < archive.cpio > archive.cpio.gz")
         check_call("bzip2 -c < archive.cpio > archive.cpio.bz2")
         try:
-            import lzma         # pylint: disable=unused-variable
             self.doXZ = subprocess.call("xz --check=crc32 --lzma2=dict=1MiB"
                                         " < archive.cpio > archive.cpio.xz", shell=True) == 0
         except Exception as ex:
-            # FIXME will issue warning even if test_xz is not requested
             warnings.warn("will not test cpio.xz: %s" % ex)
             self.doXZ = False
 

--- a/tests/test_dom0.py
+++ b/tests/test_dom0.py
@@ -3,6 +3,8 @@ from mock import patch, Mock
 
 from xcp.dom0 import default_memory, parse_mem, default_vcpus
 
+
+# pylint: disable=invalid-name
 class TestDom0(unittest.TestCase):
 
     def test_default_memory(self):
@@ -33,7 +35,7 @@ class TestDom0(unittest.TestCase):
         with patch("xcp.dom0.open_with_codec_handling") as open_mock:
             for host_gib, dom0_mib, _ in test_values:
                 mock_version(open_mock, '2.8.0')
-                expected = dom0_mib * 1024;
+                expected = dom0_mib * 1024
                 calculated = default_memory(host_gib * 1024 * 1024)
                 self.assertEqual(calculated, expected)
 
@@ -42,7 +44,7 @@ class TestDom0(unittest.TestCase):
         with patch("xcp.dom0.open_with_codec_handling") as open_mock:
             for host_gib, _, dom0_mib in test_values:
                 mock_version(open_mock, '2.9.0')
-                expected = dom0_mib * 1024;
+                expected = dom0_mib * 1024
                 calculated = default_memory(host_gib * 1024 * 1024)
                 self.assertEqual(calculated, expected)
 

--- a/xcp/dom0.py
+++ b/xcp/dom0.py
@@ -110,7 +110,7 @@ def _parse_size_and_unit(s):
         val *= 1024*1024*1024
     elif unit == "m":
         val *= 1024*1024
-    elif unit == "k" or unit == "": # default to KiB
+    elif unit in ("k", ""):
         val *= 1024
 
     return val

--- a/xcp/repository.py
+++ b/xcp/repository.py
@@ -309,11 +309,11 @@ class Repository(BaseRepository):
             repo_node = xmlunwrap.getElementsByTagName(xmldoc, ['repository'], mandatory = True)
 
             attrs = ('originator', 'name', 'product', 'version', 'build')
-            optional_attrs = ('build')
+            optional_attr = 'build'
 
             for attr in attrs:
-                self.__dict__[attr] = xmlunwrap.getStrAttribute(repo_node[0], [attr], default = None,
-                                                                mandatory = (attr not in optional_attrs))
+                self.__dict__[attr] = xmlunwrap.getStrAttribute(repo_node[0], [attr], default=None,
+                                                                mandatory = attr != optional_attr)
 
             desc_node = xmlunwrap.getElementsByTagName(xmldoc, ['description'], mandatory = True)
             self.description = xmlunwrap.getText(desc_node[0])


### PR DESCRIPTION
Fix pylint warnings:

- XCP:
  - xcp/repository.py: Unnecessary parens
  - xcp/dom0.py:  - Consider merging these comparisons with "in" to: unit in ('k', '')

- Tests:
  - tests/test_cpio.py: reimport and obsolete FIXME (the warning in that case is ok)
  - tests/test_dom0.py:
    - unnecessary semicolons
    - Variables "M" and "G" doesn't conform to '[a-z_][a-zA-Z0-9_]{0,30}$'
    (used for MegaBytes and GigaBytes only)
   
