### PR TITLE
run-pylint.py: No longer suppress most pylint messages

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -61,16 +61,12 @@ disable=W0142,W0703,C0111,R0201,W0603,W0613,W0212,W0141,
     consider-using-dict-items,
     consider-using-enumerate,
     consider-using-ternary,
-    import-outside-toplevel,
     len-as-condition,
-    multiple-imports,
-    no-else-raise,
     no-else-return,
     raise-missing-from,
     too-many-branches,
     too-many-nested-blocks,
-    unnecessary-pass,
-    wrong-import-position,
+    too-many-statements,
 
 
 [REPORTS]
@@ -158,7 +154,7 @@ notes=FIXME,XXX,TODO
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=116
 
 # Maximum number of lines in a module
 max-module-lines=5000


### PR DESCRIPTION
Pylint: update enabled checkers

- [pylintrc: Enable import-position and import-outside-toplevel](https://github.com/xenserver/python-libs/commit/af9dda2ce312c7eada97786aab331927911fe3ae)
  and disable too-many-statements as we won't refactor now. Also enable unnecessary-pass and multiple-imports.
- [run-pylint.py: No longer suppress most pylint messages](https://github.com/xenserver/python-libs/commit/9daaf03a00a5398813bcebdf9a7f1d6f08dd577b)

  Now that most pylint warnings are fixed, no longer filter all minor message classes like convention and refactor, and only filter relatively harmless messages. Improve categorisation.
  