### PR TITLE
Handle GitHub removing Py27 and move pytype from to Py3.8 to fix issues

### DIFF
--- a/.github/act-serial.yaml
+++ b/.github/act-serial.yaml
@@ -31,10 +31,6 @@ jobs:
           os: ubuntu-20.04
         - python-version: '3.10'
           os: ubuntu-latest
-        - python-version: '3.9'
-          os: ubuntu-latest
-        - python-version: '3.7'
-          os: ubuntu-latest
         - python-version: '3.6'
           os: ubuntu-20.04
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,6 @@ jobs:
           os: ubuntu-20.04
         - python-version: '3.10'
           os: ubuntu-latest
-        - python-version: '3.9'
-          os: ubuntu-latest
-        - python-version: '3.7'
-          os: ubuntu-latest
         - python-version: '3.6'
           os: ubuntu-20.04
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,23 +25,29 @@ jobs:
       matrix:
         include:
         - python-version: '3.11'
-          os: ubuntu-latest
-        # This tests with Python 2.7 and with Ubuntu-20.04's Python 3.8 for combined py2+3 coverage:
+          os: ubuntu-22.04
+        # This tests with Python 2.7 and the stock Python 3.10 for combined py2+3 coverage:
         - python-version: '2.7'
-          os: ubuntu-20.04
-        - python-version: '3.10'
-          os: ubuntu-latest
+          os: ubuntu-22.04
+        - python-version: '3.8'
+          os: ubuntu-22.04
         - python-version: '3.6'
-          os: ubuntu-20.04
+          os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Needed by diff-cover to get the changed lines: origin/master..HEAD
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        # setup-python stopped supporting Python 2.7, use https://github.com/MatteoH2O1999/setup-python
+        # This action tries to build all Python versions that actions/setup-python does not support.
+        # It caches built versions, so that after the first run, installation time is really low.
+        uses: MatteoH2O1999/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+          allow-build: info
+          cache-build: true
+          cache: pip
 
       - name: Run of tox on ubuntu-latest
         if: ${{ startsWith(matrix.python-version, '3.') && matrix.python-version != 3.6 }}
@@ -51,26 +57,26 @@ jobs:
 
       # tox >= 4.0.0 is needed for using optional-dependencies from pyproject.toml, which is
       # is not available for python <= 3.6, so use the python3.8 of Ubuntu-20.04 to install it:
-      - name: Install of tox on ubuntu-20.04 (to support optional-dependencies from pyproject.toml)
+      - name: Install of tox on ubuntu-22.04 (to support optional-dependencies from pyproject.toml)
         if: ${{ matrix.python-version == 2.7 || matrix.python-version == 3.6 }}
         run: |
           set -xv;curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-          python3.8 get-pip.py
-          python3.8 -m pip install 'virtualenv<20.22' 'tox>=4.5.1' tox-gh-actions
+          python3.10 get-pip.py
+          python3.10 -m pip install 'virtualenv<20.22' 'tox>=4.5.1' tox-gh-actions
 
-      - name: Run tox4 with Python 3.8(to support optional-dependencies from pyproject.toml) for Python3.6
+      - name: Run tox4 with Python 3.10(to support optional-dependencies from pyproject.toml) for Python3.6
         if: ${{ matrix.python-version == 3.6 }}
         run: tox --workdir .github/workflows/.tox --recreate -e py36-lint
 
-      - name: Generate combined test-coverage with Python 2.7 and 3.8 for Upload
+      - name: Generate combined test-coverage with Python 2.7 and 3.10 for Upload
         if: ${{ matrix.python-version == 2.7 }}
-        run: tox --workdir .github/workflows/.tox --recreate -e py38-covcombine
+        run: tox --workdir .github/workflows/.tox --recreate -e py310-covcombine-check
 
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.python-version == 2.7 }}
         uses: codecov/codecov-action@v3
         with:
-          directory: .github/workflows/.tox/py38-covcombine/log
+          directory: .github/workflows/.tox/py310-covcombine-check/log
           env_vars: OS,PYTHON
           fail_ci_if_error: true
           flags: unittest

--- a/run-pytype.py
+++ b/run-pytype.py
@@ -5,9 +5,61 @@ import shlex
 import sys
 from logging import INFO, basicConfig, info
 from subprocess import DEVNULL, PIPE, Popen
-from typing import List, TextIO
+from typing import List, TextIO, Tuple
 
-import pandas as pd
+import pandas as pd  # type: ignore[import]
+from toml import load
+
+
+def generate_github_annotation(match: re.Match, branch_url: str) -> str:
+    lineno = match.group(2)
+    code = match.group(5)
+    func = match.group(3)
+    msg = match.group(4)
+    msg_splitpos = msg.find(" ", 21)
+    file = match.group(1)
+    linktext = os.path.basename(file).split(".")[0]
+    source_link = f"[`{linktext}`]({branch_url}/{file}#L{lineno})"
+    row = {
+        "Location": source_link,
+        "Function": f"`{func}`",
+        "Error code": code,
+        "Error message": msg[:msg_splitpos] + "<br>" + msg[msg_splitpos + 1 :],
+        "Error description": "",
+    }
+    # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+    return f"::error file={file},line={lineno},title=pytype: {code}::{msg}"
+
+
+def filter_line(line, row):
+    if line.startswith("For more details, see"):
+        row["Error code"] = f"[{row['Error code']}]({line[22:]})"
+        return " " + line[22:]
+    if not row["Error description"]:
+        row["Error description"] = line.lstrip()
+    else:
+        row["Error description"] += " " + line.lstrip()
+    return ", " + line
+
+
+def skip_uninteresting_lines(line: str) -> bool:
+    if not line or line[0] == "/" or line.startswith("FAILED:"):
+        return True
+    if line[0] == "[":
+        pos = line.rfind(os.getcwd())
+        printfrom = pos + len(os.getcwd()) + 1 if pos > 0 else line.index("]") + 2
+        info("PROGRESS: " + line[1:].split("]")[0] + ": " + line[printfrom:])
+        return True
+    if line.startswith("ninja: "):
+        line = line[7:]
+    return bool(
+        (
+            line.startswith("Entering")
+            or line.startswith("Leaving")
+            or line.startswith("Computing")
+            or line.startswith("Analyzing")
+        )
+    )
 
 
 def run_pytype(command: List[str], branch_url: str, errorlog: TextIO, results):
@@ -16,46 +68,18 @@ def run_pytype(command: List[str], branch_url: str, errorlog: TextIO, results):
     popen = Popen(command, stdout=PIPE, stderr=DEVNULL, universal_newlines=True)
     error = ""
     row = {}  # type: dict[str, str]
-    while True:
-        if not popen.stdout:
-            break
+    while popen.stdout:
         line = popen.stdout.readline()
         if line == "" and popen.poll() is not None:
             break
         line = line.rstrip()
-
-        if not line or line[0] == "/" or line.startswith("FAILED:"):
-            continue
-        if line[0] == "[":
-            pos = line.rfind(os.getcwd())
-            if pos > 0:
-                printfrom = pos + len(os.getcwd()) + 1
-            else:
-                printfrom = line.index("]") + 2
-            info("PROGRESS: " + line[1:].split("]")[0] + ": " + line[printfrom:])
-            continue
-        elif line.startswith("ninja: "):
-            line = line[7:]
-        if (
-            line.startswith("Entering")
-            or line.startswith("Leaving")
-            or line.startswith("Computing")
-            or line.startswith("Analyzing")
-        ):
+        if skip_uninteresting_lines(line):
             continue
         info(line)
         if row:
             if line == "" or line[0] == " " or line.startswith("For more details, see"):
                 if line:
-                    if line.startswith("For more details, see"):
-                        row["Error code"] = f"[{row['Error code']}]({line[22:]})"
-                        error += " " + line[22:]
-                    else:
-                        if not row["Error description"]:
-                            row["Error description"] = line.lstrip()
-                        else:
-                            row["Error description"] += " " + line.lstrip()
-                        error += ", " + line
+                    error += filter_line(line, row)
                 continue
             errorlog.write(
                 error
@@ -68,23 +92,7 @@ def run_pytype(command: List[str], branch_url: str, errorlog: TextIO, results):
             r'File ".*libs/([^"]+)", line (\S+), in ([^:]+): (.*) \[(\S+)\]', line
         )
         if match:
-            lineno = match.group(2)
-            code = match.group(5)
-            func = match.group(3)
-            msg = match.group(4)
-            msg_splitpos = msg.find(" ", 21)
-            file = match.group(1)
-            linktext = os.path.basename(file).split(".")[0]
-            source_link = f"[`{linktext}`]({branch_url}/{file}#L{lineno})"
-            row = {
-                "Location": source_link,
-                "Function": f"`{func}`",
-                "Error code": code,
-                "Error message": msg[:msg_splitpos] + "<br>" + msg[msg_splitpos + 1 :],
-                "Error description": "",
-            }
-            # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
-            error = f"::error file={file},line={lineno},title=pytype: {code}::{msg}"
+            error = generate_github_annotation(match, branch_url)
     if popen.stdout:
         popen.stdout.close()
     return_code = popen.wait()
@@ -99,7 +107,7 @@ def to_markdown(me, fp, results, branch_url):
     fp.write("\n")
 
 
-def main(me: str, branch_url: str):
+def pytype_with_github_annotations_to_stdout(me: str, xfail_files: list, branch_url: str):
     """Send pytype errors to stdout.
 
     Args:
@@ -107,34 +115,26 @@ def main(me: str, branch_url: str):
         output_file (str): output file path for the markdown summary table
         branch_url (str): _url of the branch for file links in the summary table
     """
-    never = (
-        "xcp/repository.py",
-        "tests/test_ifrename_logic.py",
-        "tests/test_xmlunwrap.py",
-    )
-    excludes = [
-        "xcp/cmd.py",
-        "xcp/net/ip.py",
-    ]
-    errors_in = excludes.copy()
-    errors_in.extend(never)
     base = [
         "pytype",
+        "-j",
+        "auto",
         "-k",
         "--config",
         ".github/workflows/pytype.cfg",
     ]
     command = base.copy()
-    command.extend(["--exclude", " ".join(errors_in)])
+    if xfail_files:
+        command.extend(["--exclude", " ".join(xfail_files)])
 
     def call_pytype(outfp):
         exit_code, results = run_pytype(command, branch_url, sys.stderr, [])
-        for exclude in excludes:
+        for xfail_file in xfail_files:
             command2 = base.copy()
-            command2.append(exclude)
+            command2.append(xfail_file)
             err_code, results = run_pytype(command2, branch_url, outfp, results)
             if err_code == 0:
-                print("No errors in", exclude)
+                print("No errors in", xfail_file)
         return exit_code, results
 
     exit_code, results = call_pytype(sys.stdout)
@@ -149,17 +149,23 @@ def main(me: str, branch_url: str):
     sys.exit(exit_code)
 
 
-if __name__ == "__main__":
-    scriptname = os.path.basename(__file__).split(".")[0]
-    basicConfig(format=scriptname + ": %(message)s", level=INFO)
-    filelink_baseurl = "https://github.com/xenserver/python-libs/blob/master"
+def setup_and_run_pytype_action(scriptname: str):
+    config = load("pyproject.toml")
+    pytype = config["tool"].get("pytype")
+    xfail_files = pytype.get("xfail", []) if pytype else []
+    repository_url = config["project"]["urls"]["repository"].strip(" /")
+    filelink_baseurl = repository_url + "/blob/master"
+    # When running as a GitHub action, we want to use URL of the fork with the GitHub action:
     server_url = os.environ.get("GITHUB_SERVER_URL", None)
     repository = os.environ.get("GITHUB_REPOSITORY", None)
     if server_url and repository:
         # https://github.com/orgs/community/discussions/5251 only set on Pull requests:
-        branch = os.environ.get("GITHUB_HEAD_REF", None)
-        if not branch:
-            # Always set but set to num/merge on PR, but to branch on pushes:
-            branch = os.environ.get("GITHUB_REF_NAME", None)
+        branch = os.environ.get("GITHUB_HEAD_REF", None) or os.environ.get("GITHUB_REF_NAME", None)
         filelink_baseurl = f"{server_url}/{repository}/blob/{branch}"
-    main(scriptname, filelink_baseurl)
+    pytype_with_github_annotations_to_stdout(scriptname, xfail_files, filelink_baseurl)
+
+
+if __name__ == "__main__":
+    scriptname = os.path.basename(__file__).split(".")[0]
+    basicConfig(format=scriptname + ": %(message)s", level=INFO)
+    setup_and_run_pytype_action(scriptname)

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 # Later in the order:
 # 3. pyre and mypy
 # 4. pytype
-envlist = py36-lint, py311-pyre, py310-check, py38-pytype, py38-covcombine
+envlist = py36-lint, py311-pyre, py38-pytype, py310-covcombine-check
 isolated_build = true
 skip_missing_interpreters = true
 requires =

--- a/tox.ini
+++ b/tox.ini
@@ -63,8 +63,8 @@ deps =
     pyre: pyright
     pytype: {[pytype]deps}
 allowlist_externals =
-    {cov,covcp,covcombine,fox,check,lint,test,pytype,pyre,mdreport}: echo
-    {cov,covcp,covcombine,fox,check,lint,test,pytype,pyre,mdreport}: sh
+    {cov,covcp,covcombine,fox,check,lint,test,mdreport}: echo
+    {cov,covcp,covcombine,fox,check,lint,test,mdreport}: sh
     {cov,covcp,covcombine,fox}: cp
     {covcombine,fox}: tox
     check: cat
@@ -104,14 +104,14 @@ setenv =
 commands =
     lint: {[lint]commands}
     pyre: {[pyre]commands}
+    check: {[check]commands}
     pytype: {[pytype]commands}
-    {cov,covcp,covcombine,check,fox,lint,test,pytype,mdreport}: {[test]commands}
+    {cov,covcp,covcombine,check,fox,lint,test,mdreport}: {[test]commands}
     # covcombine shall not call [cov]commands: diff-cover shall check the combined cov:
     {cov,covcp}: {[cov]commands}
     {py27-test}: pylint --py3k --disable=no-absolute-import xcp/
     covcp: cp -av {envlogdir}/coverage.xml {env:UPLOAD_DIR:.}
     covcombine: {[covcombine]commands}
-    check: {[check]commands}
     fox: {[covcombine]commands}
     fox: {[lint]commands}
     fox: {[fox]commands}
@@ -126,7 +126,7 @@ commands    =
     coverage html -d {envlogdir}/htmlcov
     coverage html -d {envlogdir}/htmlcov-tests --fail-under {env:TESTS_COV_MIN:96}    \
                       --include="tests/*"
-    diff-cover --compare-branch=origin/master                                         \
+    diff-cover --compare-branch=origin/master --include-untracked                     \
       {env:PY3_DIFFCOVER_OPTIONS} --fail-under {env:DIFF_COV_MIN:92}                  \
       --html-report  {envlogdir}/coverage-diff.html                                   \
                      {envlogdir}/coverage.xml
@@ -158,7 +158,7 @@ deps = pylint
     pandas
     tabulate
 commands =
-    python run-pylint.py xcp
+    python run-pylint.py xcp tests
     diff-quality --compare-branch=origin/master --violations=pylint                   \
       --ignore-whitespace --fail-under 100                                            \
       --html-report  {envlogdir}/pylint-diff.html {envlogdir}/pylint.txt
@@ -201,7 +201,7 @@ max-line-length = 129
 commands =
     pyre: python3.11 --version -V # Needs py311-pyre, does not work with py310-pyre
     python ./run-pyre.py
-    {[test]commands}
+    -pyright
 
 [pytype]
 deps = pytype

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 # Later in the order:
 # 3. pyre and mypy
 # 4. pytype
-envlist = py36-lint, py311-pyre, py39-check, py310-pytype, py37-mdreport, py38-covcombine
+envlist = py36-lint, py311-pyre, py310-check, py38-pytype, py38-covcombine
 isolated_build = true
 skip_missing_interpreters = true
 requires =
@@ -48,6 +48,7 @@ description = Run in a {basepython} virtualenv:
     pytype:     Run pytype for static analyis, intro: https://youtu.be/abvW0mOrDiY
 # checkers(mypy) need the pytest dependices as well:
 extras =
+    {check,pytype}: {[check]extras}
     {cov,covcp,covcombine,fox,check,lint,test,pytype,pyre,mdreport}: {[test]extras}
     {cov,covcp,covcombine,fox}:                                      {[cov]extras}
 deps =
@@ -57,10 +58,9 @@ deps =
     {cov,covcp,covcombine,fox}: coverage[toml]
     {cov,covcp,covcombine,fox}: diff-cover
     {lint,fox}: {[lint]deps}
-    check: {[check]deps}
     pyre: pyre-check
     pyre: pyre-extensions
-    pytype: {[check]deps}
+    pyre: pyright
     pytype: {[pytype]deps}
 allowlist_externals =
     {cov,covcp,covcombine,fox,check,lint,test,pytype,pyre,mdreport}: echo
@@ -188,17 +188,14 @@ python =
     3.11: py311
 
 [check]
-deps =
-    lxml
-    mypy
-    mypy-extensions
-    typing_extensions
-    types-mock
-    types-simplejson
-    types-six
+extras = mypy
 commands =
-    mypy --txt-report .
-    cat index.txt
+    mypy --txt-report {envlogdir}
+    cat {envlogdir}/index.txt
+
+[pycodestyle]
+ignore = W191,W293,W504,E101,E126,E127,E201,E202,E203,E221,E222,E226,E227,E241,E251,E261,E262,E265,E301,E302,E303,E305,E722,W391,E401,E402,E741
+max-line-length = 129
 
 [pyre]
 commands =
@@ -210,5 +207,6 @@ commands =
 deps = pytype
     pandas
 commands =
-    python3.10 --version -V # Needs py310, does not support with py311 yet:
+    python3.8 -V # Needs python <= 3.10; but 3.10 has an issue with newer xml.dom.minidom
+    pytype --version
     python ./run-pytype.py


### PR DESCRIPTION
Note: Because of the announcement of removal of Python 2.7 for setup-python in https://github.com/actions/setup-python/issues/672, use a wrapper for setup-python which can build missing Python versions.

### Commits:
- [run-pytype.py: Empty the list of excludes and xfails](https://github.com/xenserver/python-libs/commit/bae99960b42b5d0a952c35d1969b7af57d1892fd)

  * As pytype errors are fixed, clear excludes and xfails

- [tox.ini and CI: Move pytype to Py3.8 and remove 3.7 and 3.9 builds](https://github.com/xenserver/python-libs/pull/93/commits/2f6fdd833e4299a85223e23fe623df620e101b8c)

  - pytype has several problems to import libraries when used on Python 3.10, therefore move it Python 3.8.
  - tox.ini, GitHub CI: Remove builds for 3.7 and 3.9 builds because they showed intermittent pytest failures and we shoud not use them as new Python versions anyway
 
- [.github/workflows/main.yml: Py2.7: Use a wrapper for setup-python](https://github.com/xenserver/python-libs/pull/93/commits/a0b8a36a214dfadd428eed3e39d75622c77d75ca)

  - Because of the announcement of removal of Python 2.7 for setup-python in https://github.com/actions/setup-python/issues/672, use a wrapper for setup-python which can build missing Python versions.