### PR TITLE
xcp/repository.py: Final pylint & pyright static analysis fixes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,8 @@ source =
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =
+    # Don't complain if tests don't hit catch-all exception handlers:
+    except Exception
     # Have to re-enable the standard pragma
     pragma: no cover
 

--- a/xcp/repository.py
+++ b/xcp/repository.py
@@ -247,6 +247,10 @@ class Repository(BaseRepository):
         self._md5 = md5()
         self.requires = []
         self.packages = []
+        self.name = ""
+        self.version = ""
+        self.build = ""
+        self.originator = ""
 
         access.start()
 
@@ -379,7 +383,7 @@ class Repository(BaseRepository):
                 if r.identifier == cls.XCP_MAIN_IDENT:
                     repo_ver = r.product_version
                     break
-        except:
+        except Exception:
             pass
 
         return repo_ver


### PR DESCRIPTION
- Fix bare "except:": Bare except's also catch fatal exceptions like SystemExit and KeyboardInterrupt, which is why pylint warns about it. https://www.flake8rules.com/rules/E722.html
- Add init of name, version, build, originator to `__init__()` to fix warnings for init outside of `__init__()`