### PR TITLE
.github/workflows/main.yml: Cancel obsolete GitHub workflows

### DIFF
--- a/.github/act-serial.yaml
+++ b/.github/act-serial.yaml
@@ -5,6 +5,10 @@
 
 name: Unit tests
 
+concurrency:  # On new workflow, cancel old workflows from the same PR, branch or tag:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Checks can be skipped by adding "skip-checks: true" to a commit message,
 # or requested by adding "request-checks: true" if disabled by default for pushes:
 # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#skipping-and-requesting-checks-for-individual-commits

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@
 
 name: Unit tests
 
+concurrency:  # On new workflow, cancel old workflows from the same PR, branch or tag:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Checks can be skipped by adding "skip-checks: true" to a commit message,
 # or requested by adding "request-checks: true" if disabled by default for pushes:
 # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#skipping-and-requesting-checks-for-individual-commits


### PR DESCRIPTION
When an update is pushed to a PR, branch or tag, cancel currently running workflows on the same when a new workflow is triggered.

Other repos have similar cancel-in-progress in place as well:
https://github.com/spack/spack/blob/ba7ae2c153761d505063ac6727b8c939b2283ea1/.github/workflows/ci.yaml#L14C68-L14C85

This reduces compute usage when new changes are pushed when previous GitHub CI jobs were still running.