### PR TITLE
Pin tox to 4.5.1,update act workflow

### DIFF
--- a/.github/act-serial.yaml
+++ b/.github/act-serial.yaml
@@ -25,14 +25,12 @@ jobs:
       matrix:
         include:
         # This tests with Python 2.7 and with Ubuntu-20.04's Python 3.8 for combined py2+3 coverage:
-        - python-version: '3.11'
-          os: ubuntu-latest
-        - python-version: '2.7'
-          os: ubuntu-20.04
-        - python-version: '3.10'
-          os: ubuntu-latest
         - python-version: '3.6'
           os: ubuntu-20.04
+        - python-version: '3.10'
+          os: ubuntu-22.04
+        - python-version: '3.11'
+          os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -43,25 +41,22 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Python 2.7 using apt-get install
+        if: ${{ matrix.python-version == 3.10 }}
+        run: apt-get update && apt-get install -y python2-dev
+
       - name: Run of tox on ubuntu-latest
         if: ${{ startsWith(matrix.python-version, '3.') && matrix.python-version != 3.6 }}
         run: |
-          pip install 'virtualenv<20.22' 'tox>=4.5.1' tox-gh-actions
+          pip install 'virtualenv<20.22' 'tox==4.5.1' tox-gh-actions
           tox --workdir .github/workflows/.tox --recreate
 
       # tox >= 4.0.0 is needed for using optional-dependencies from pyproject.toml, which is
       # is not available for python <= 3.6, so use the python3.8 of Ubuntu-20.04 to install it:
-      - name: Install of tox on ubuntu-20.04 (to support optional-dependencies from pyproject.toml)
-        if: ${{ matrix.python-version == 2.7 || matrix.python-version == 3.6 }}
+      - name: Tox on ${{ matrix.os }} (Using 3.8 to use extras from pyproject.toml)
+        if: ${{ matrix.python-version == 3.6 }}
         run: |
           set -xv;curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           python3.8 get-pip.py
-          python3.8 -m pip install 'virtualenv<20.22' 'tox>=4.5.1' tox-gh-actions
-
-      - name: Run tox4 with Python 3.8(to support optional-dependencies from pyproject.toml) for Python3.6
-        if: ${{ matrix.python-version == 3.6 }}
-        run: tox --workdir .github/workflows/.tox --recreate -e py36-lint
-
-      - name: Generate combined test-coverage with Python 2.7 and 3.8 for Upload
-        if: ${{ matrix.python-version == 2.7 }}
-        run: tox --workdir .github/workflows/.tox --recreate -e py38-covcombine
+          python3.8 -m pip install 'virtualenv<20.22' 'tox==4.5.1'
+          tox --workdir .github/workflows/.tox --recreate -e py36-lint-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run of tox on ubuntu-latest
         if: ${{ startsWith(matrix.python-version, '3.') && matrix.python-version != 3.6 }}
         run: |
-          pip install 'virtualenv<20.22' 'tox>=4.5.1' tox-gh-actions
+          pip install 'virtualenv<20.22' 'tox==4.5.1' tox-gh-actions
           tox --workdir .github/workflows/.tox --recreate
 
       # tox >= 4.0.0 is needed for using optional-dependencies from pyproject.toml, which is
@@ -62,7 +62,9 @@ jobs:
         run: |
           set -xv;curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           python3.10 get-pip.py
-          python3.10 -m pip install 'virtualenv<20.22' 'tox>=4.5.1' tox-gh-actions
+          # Use tox==4.5.1: tox>=4 is needed for reading the extras from pyproject.toml
+          # while tox>=4.5.2 depends on virutalenv>=20.23, which breaks Python 2.7:
+          python3.10 -m pip install 'virtualenv<20.22' 'tox==4.5.1' tox-gh-actions
 
       - name: Run tox4 with Python 3.10(to support optional-dependencies from pyproject.toml) for Python3.6
         if: ${{ matrix.python-version == 3.6 }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,9 @@ pytype = [
 tox = [
     # The latest versions of tox need 'py>=1.11.0' and this is not stated in the deps of tox-4.5.1.
     "py>=1.11.0",
-    # tox>=4 is needed in order to fix reading the python2.7 deps from pyproject.toml
-    "tox>=4.5.1; python_version >= '3.7'",
+    # Use tox==4.5.1: tox>=4 is needed for reading the extras from pyproject.toml
+    # while tox>=4.5.2 depends on virutalenv>=20.23, which breaks Python 2.7:
+    "tox==4.5.1; python_version >= '3.7'",
     "tox-gh-actions; python_version >= '3.7'",
     # virtualenv-20.22 breaks using python2.7 for the `py27` virtualenv with tox and newer
     # versions even break py36(which is also EOL) because py36 does not support

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,9 @@ skip_missing_interpreters = true
 requires =
     # The latest versions of tox need 'py>=1.11.0' and this is not stated in the deps of tox-4.5.1.
     py>=1.11.0
-    # tox>=4 is needed in order to fix reading the python2.7 deps from pyproject.toml
-    tox>=4.5.1; python_version >= '3.7'
+    # Use tox==4.5.1: tox>=4 is needed for reading the extras from pyproject.toml
+    # while tox>=4.5.2 depends on virutalenv>=20.23, which breaks Python 2.7:
+    tox==4.5.1; python_version >= '3.7'
     tox-gh-actions; python_version >= '3.7'
     # virtualenv-20.22 breaks using python2.7 for the `py27` virtualenv with tox and newer
     # versions even break py36(which is also EOL) because py36 does not support


### PR DESCRIPTION
Two closely related commits:

### CI, pyproject.toml, tox.ini: Pin tox to 4.5.1 as 4.5.2 breaks Py27
    
Pin tox to 4.5.1: tox>=4 is needed for reading the extras from
pyproject.toml while tox>=4.5.2 depends on virutalenv>=20.23,
which breaks Python 2.7 in turn.

### .github/act-serial.yaml: Pin tox to 4.5.1, fix Python 2.7
    
Fix the config file for testing GitHub action runs locally to pin tox to 4.5.1 (see previous commit) and fix Python 2.7
