### PR TITLE
Fix run-pylint.py for pytype

### DIFF
--- a/.github/workflows/pytype.cfg
+++ b/.github/workflows/pytype.cfg
@@ -1,3 +1,6 @@
+# pytype does not support pyproject.toml natively yet:
+# https://github.com/google/pytype/issues/645
+
 # NOTE: All relative paths are relative to the location of this file.
 
 [pytype]
@@ -6,14 +9,14 @@
 exclude =
 
 # Space-separated list of files or directories to process.
-inputs = ../../xcp ../../tests
+inputs = ../../xcp ../../tests ../../*.py
 
 # Keep going past errors to analyze as many files as possible.
 keep_going = True
 
 # Run N jobs in parallel. When 'auto' is used, this will be equivalent to the
 # number of CPUs on the host system.
-jobs = 4
+jobs = auto
 
 # All pytype output goes here.
 output = .pytype
@@ -59,7 +62,7 @@ overriding_parameter_count_checks = True
 #strict_primitive_comparisons = True
 
 # Space-separated list of error names to ignore.
-# disable = pyi-error
+disable = pyi-error, ignored-type-comment
 
 # Don't report errors.
 #report_errors = True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
         additional_dependencies:
         -   six
         -   mock
+        -   pandas
 -   repo: local
     hooks:
     -   id: run-pyre

--- a/run-pylint.py
+++ b/run-pylint.py
@@ -29,8 +29,8 @@ import json
 import os
 import sys
 from glob import glob
-from io import StringIO, TextIOWrapper
-from typing import List
+from io import StringIO
+from typing import List, TextIO
 
 from pylint.lint import Run  # type: ignore[import]
 from pylint.reporters import JSONReporter  # type: ignore[import]
@@ -111,7 +111,7 @@ pylint_options: List[str] = [
     "--load-plugins", "pylint.extensions.eq_without_hash",
 ]
 
-def pylint_project(check_dirs: List[str], errorlog: TextIOWrapper, branch_url: str):
+def pylint_project(check_dirs: List[str], errorlog: TextIO, branch_url: str):
 
     pylint_overview = []
     pylint_results = []


### PR DESCRIPTION
- `run-pylint.py`: Fix pytype errors in CI script run-pylint.py
- `.github/workflows/pytype.cfg`: Enable checking /*.py as well    
  - and use all CPUs for parallel checking
  - and tolerate pyi-error and ignored-type-comment (comments which other tools use)
