### PR TITLE
Make runCmd() default to text; compatible with host-installer code

### DIFF
--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -65,10 +65,13 @@ class TestCache(unittest.TestCase):
     def test_fileContents_pciids_binstr(self):
         contents_bytes = self.c.fileContents("tests/data/pci.ids", mode="rb")
         contents_string = self.c.fileContents("tests/data/pci.ids", mode="r")
+        contents_default = self.c.fileContents("tests/data/pci.ids")
         self.assertIsInstance(contents_bytes, bytes)
         self.assertIsInstance(contents_string, str)
+        self.assertIsInstance(contents_default, str)
         self.assertEqual(contents_bytes, six.ensure_binary(contents_string))
         self.assertEqual(contents_string, six.ensure_str(contents_bytes))
+        self.assertEqual(contents_default, six.ensure_str(contents_bytes))
 
     def test_runCmd(self):
         output_data = "line1\nline2\n"

--- a/xcp/cmd.py
+++ b/xcp/cmd.py
@@ -25,9 +25,11 @@
 
 import subprocess
 import sys
+from typing import Any, cast
 
 from xcp import logger
 from xcp.compat import open_defaults_for_utf8_text
+
 
 def _encode_command_to_bytes(command):
     # When the locale not an UTF-8 locale, Python3.6 Popen can't deal with ord() >= 128
@@ -44,6 +46,7 @@ def _encode_command_to_bytes(command):
     return command
 
 def runCmd(command, with_stdout=False, with_stderr=False, inputtext=None, **kwargs):
+    # type: (bytes | str | list[str], bool, bool, bytes | str | None, Any) -> Any
     # sourcery skip: assign-if-exp, hoist-repeated-if-condition, reintroduce-else
 
     if inputtext is not None:
@@ -59,12 +62,12 @@ def runCmd(command, with_stdout=False, with_stderr=False, inputtext=None, **kwar
 
     # pylint: disable-next=unexpected-keyword-arg
     cmd = subprocess.Popen(command, bufsize=(1 if sys.version_info < (3, 3) else -1),
-                           stdin=(inputtext and subprocess.PIPE or None),
+                           stdin=cast(int, inputtext and subprocess.PIPE or None),
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE,
                            shell=not isinstance(command, list),
                            **kwargs)
-    (out, err) = cmd.communicate(inputtext)
+    (out, err) = cmd.communicate(cast(str, inputtext))
     rv = cmd.returncode
 
     l = "ran %s; rc %d" % (str(command), rv)

--- a/xcp/compat.py
+++ b/xcp/compat.py
@@ -52,9 +52,7 @@ def open_defaults_for_utf8_text(args, kwargs):
         mode = args[0]
     if sys.version_info < (3, 0):
         return mode, other_kwargs
-    if not mode or not isinstance(mode, str):
-        raise ValueError("The mode argument is required! r for text, rb for binary")
     if sys.version_info >= (3, 0) and "b" not in mode:
         kwargs.setdefault("encoding", "utf-8")
         kwargs.setdefault("errors", "replace")
-    return mode, other_kwargs
+    return mode or "r", other_kwargs


### PR DESCRIPTION
Revert a change I had made without having had checked the use of `runCmd()` in host-installer:

Thus, no longer require an additional mode argument (all uses in host-installer return text, not binary data) to be able to use the same code for host-installer:

- [xcp/compat.py: open_defaults_for_utf8_text() Default to text mode](https://github.com/xenserver/python-libs/pull/107/commits/86180c07b71ba78b6bb200c74760eaac354a0882)

  - For xcp.cmd.runCmd() to be compatible with host-installer's runCmd, make `mode="r"` the default for runCmd(all commands in host-installer return text, not binary data to the caller)

- [tests/test_mountingaccessor.py: Fix tests to not mock xcp.cmd.runCmd()](https://github.com/xenserver/python-libs/pull/107/commits/b88317df57f7ad06f96949bd09a2387bf17a4deb)

   - Test `MountingAccessor` without mocking `xcp.cmd.runCmd()`. Instead, mock the subprocess calls for mounting and umounting to verify `xcp.cmd.runCmd()`