### PR TITLE
GitHub CI/tox.ini: Re-enable test report in GitHub Actions summary

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 # This is the order how tox runs the tests when used interactively during development.
 # Run the tests which uncover issues most often first! For example:
-# 1. changed, but not covered lines
-# 2. pylint warnings in changed lines
-# Later in the order:
-# 3. pyre and mypy
-# 4. pytype
-envlist = py36-lint, py311-pyre, py38-pytype, py310-covcombine-check
+# 1. python 2.7 and 3.10 coverage test for changed, but not covered lines and mypy check
+# 2. python 3.6 test and pylint warnings from changed lines
+# 3. pytype (needs Python 3.8 for best results)
+# 4. pyre and pyright checks, pytest test report as markdown for GitHub Actions summary
+envlist = py310-covcombine-check, py36-lint-test, py38-pytype, py311-pyre-mdreport
 isolated_build = true
 skip_missing_interpreters = true
 requires =
@@ -27,7 +26,7 @@ commands    =
     # https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md
     # https://github.com/actions/toolkit/blob/main/docs/commands.md#problem-matchers
     echo "::add-matcher::.github/workflows/PYTHONWARNINGS-problemMatcher.json"
-    pytest --cov -v {env:PYTEST_MD_REPORT} --new-first -x --show-capture=all -rA
+    pytest --cov -v --new-first -x --show-capture=all -rA
     sh -c 'ls -l {env:COVERAGE_FILE}'
     sh -c 'if [ -n "{env:PYTEST_MD_REPORT_OUTPUT}" -a -n "{env:GITHUB_STEP_SUMMARY}" ];then    \
       sed -i "s/tests\(.*py\)/[&](&)/" {env:PYTEST_MD_REPORT_OUTPUT}; sed "/title/,/\/style/d" \
@@ -94,7 +93,8 @@ setenv =
     # Inhibit dev-warnings on pytest plugins, but we enable dev-warnings in conftest.py
     PYTHONWARNINGS=ignore  # for our code, for full warnings except for pytest plugins
     COVERAGE_FILE={envlogdir}/.coverage
-    mdreport: PYTEST_MD_REPORT=--md-report
+    mdreport: PYTEST_MD_REPORT=True
+    mdreport: PYTEST_MD_REPORT_VERBOSE=0
     mdreport: PYTEST_MD_REPORT_COLOR=never
     mdreport: PYTEST_MD_REPORT_OUTPUT={envlogdir}/pytest-md-report.md
     mdreport: PYTEST_MD_REPORT_TEE=1
@@ -106,7 +106,7 @@ commands =
     pyre: {[pyre]commands}
     check: {[check]commands}
     pytype: {[pytype]commands}
-    {cov,covcp,covcombine,check,fox,lint,test,mdreport}: {[test]commands}
+    {cov,covcp,covcombine,check,fox,test,mdreport}: {[test]commands}
     # covcombine shall not call [cov]commands: diff-cover shall check the combined cov:
     {cov,covcp}: {[cov]commands}
     {py27-test}: pylint --py3k --disable=no-absolute-import xcp/
@@ -121,6 +121,7 @@ description = Generate coverage html reports (incl. diff-cover) for this environ
 setenv      = PY3_DIFFCOVER_OPTIONS=--ignore-whitespace --show-uncovered
        py27:  PY3_DIFFCOVER_OPTIONS=
 extras      = coverage
+    test
 commands    =
     coverage xml  -o {envlogdir}/coverage.xml  --fail-under {env:XCP_COV_MIN:68}
     coverage html -d {envlogdir}/htmlcov


### PR DESCRIPTION
Initially, the pytest report for the GitHub Actions summary was overly verbose with a too large Markdown table:

* Re-enable the mdreport as a summary (less verbose) for verifying executed and skipped tests.