### PR TITLE
Fix pylint warnings in net/ifrename/{dynamic,static}.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,8 +48,10 @@ repos:
             ]
         log_file: ".git/pre-commit-pylint.log"
         additional_dependencies:
+        -   pyfakefs
         -   six
         -   mock
+        -   pandas
 -   repo: local
     hooks:
     -   id: run-pyre

--- a/tests/test_ifrename_dynamic.py
+++ b/tests/test_ifrename_dynamic.py
@@ -96,6 +96,21 @@ class TestGenerate(unittest.TestCase):
         closeLogs()
         self.logbuf.close()
 
+    def test_label(self):
+        """Cover the label handling of DynamicRules.generate()"""
+        dr = DynamicRules()
+        dr.formulae = {"eth0": ("label", "label1"), "eth1": ("label", "label2")}
+        dr.generate(
+            [
+                MACPCI("00:1E:67:31:59:89", "0000:00:19.0", label="label1"),
+                MACPCI("00:1E:67:31:59:88", "0000:02:00.0", label="label2"),
+            ]
+        )
+        assert set(dr.rules) == {
+            MACPCI("00:1E:67:31:59:89", "0000:00:19.0", tname="label1"),
+            MACPCI("00:1E:67:31:59:88", "0000:02:00.0", tname="label2"),
+        }
+
     def test_ppn_quirks(self):
         # Test case taken from example on CA-75599
 

--- a/xcp/net/ifrename/dynamic.py
+++ b/xcp/net/ifrename/dynamic.py
@@ -188,7 +188,7 @@ class DynamicRules(object):
                                 "the %s dynamic rule" % (value, target))
                 continue
 
-            elif method == "ppn":
+            if method == "ppn":
 
                 if ppn_quirks:
                     LOG.info("Not considering formula for '%s' due to ppn "
@@ -209,7 +209,7 @@ class DynamicRules(object):
                                 "%s dynamic rule" % (value, target))
                 continue
 
-            elif method == "pci":
+            if method == "pci":
                 try:
                     nic = pci_sbdfi_to_nic(value, state)
                     rule = MACPCI(nic.mac, nic.pci, tname=target)
@@ -220,7 +220,7 @@ class DynamicRules(object):
 
                 continue
 
-            elif method == "label":
+            if method == "label":
 
                 for nic in state:
                     if nic.label == value:
@@ -236,8 +236,7 @@ class DynamicRules(object):
                                 "the %s dynamic rule" % (value, target))
                 continue
 
-            else:
-                LOG.critical("Unknown dynamic rule method %s" % method)
+            LOG.critical("Unknown dynamic rule method %s" % method)
 
 
     def write(self, header = True):

--- a/xcp/net/ifrename/dynamic.py
+++ b/xcp/net/ifrename/dynamic.py
@@ -30,7 +30,7 @@ beginning with a # character.
 
 from __future__ import unicode_literals
 
-from ...compat import open_with_codec_handling
+from os.path import exists as pathexists
 
 __version__ = "1.0.0"
 __author__  = "Andrew Cooper"
@@ -45,10 +45,10 @@ except ImportError:
         pass
 
 
+from xcp.compat import open_with_codec_handling
 from xcp.logger import LOG
 from xcp.net.ifrename.macpci import MACPCI
 from xcp.pci import pci_sbdfi_to_nic
-from os.path import exists as pathexists
 
 SAVE_HEADER = (
     "# Automatically adjusted file.  Do not edit unless you are "

--- a/xcp/net/ifrename/static.py
+++ b/xcp/net/ifrename/static.py
@@ -241,7 +241,7 @@ class StaticRules(object):
                                 "the %s static rule" % (value, target))
                 continue
 
-            elif method == "ppn":
+            if method == "ppn":
 
                 if ppn_quirks:
                     LOG.info("Not considering formula for '%s' due to ppn "
@@ -262,7 +262,7 @@ class StaticRules(object):
                                 "%s static rule" % (value, target))
                 continue
 
-            elif method == "pci":
+            if method == "pci":
                 try:
                     nic = pci_sbdfi_to_nic(value, state)
                     rule = MACPCI(nic.mac, nic.pci, tname=target)
@@ -273,7 +273,7 @@ class StaticRules(object):
 
                 continue
 
-            elif method == "label":
+            if method == "label":
 
                 for nic in state:
                     if nic.label == value:
@@ -289,8 +289,7 @@ class StaticRules(object):
                                 "the %s static rule" % (value, target))
                 continue
 
-            else:
-                LOG.critical("Unknown static rule method %s" % method)
+            LOG.critical("Unknown static rule method %s" % method)
 
     def write(self, header = True):
 

--- a/xcp/net/ifrename/static.py
+++ b/xcp/net/ifrename/static.py
@@ -40,18 +40,18 @@ Any line starting with '#' is considered to be a comment
 
 from __future__ import unicode_literals
 
-from ...compat import open_with_codec_handling
+from os.path import exists as pathexists
 
 __version__ = "1.1.1"
 __author__  = "Andrew Cooper"
 
 import re
 
+from xcp.compat import open_with_codec_handling
 from xcp.logger import LOG
-from xcp.net.mac import VALID_COLON_MAC as VALID_MAC
 from xcp.net.ifrename.macpci import MACPCI
+from xcp.net.mac import VALID_COLON_MAC as VALID_MAC
 from xcp.pci import VALID_SBDFI as VALID_PCI
-from os.path import exists as pathexists
 from xcp.pci import pci_sbdfi_to_nic
 
 VALID_LINE = re.compile(


### PR DESCRIPTION
## Fix pylint warnings
* The added test case is only to have test coverage for a case which wasn't covered yet.
## Commits
- [tests/test_ifrename_dynamic.py: Add test to cover label handling](https://github.com/xenserver/python-libs/commit/339bc3da363d7d31bcfb53824a2dafb9d9fd87b3)
  - Cover label handling in DynamicRules.generate() to have coverage for the next commit.
  - Add pyfakefs and pandas to the pylint environment of pre-commit to allow pre-commit's pylint stage to succeed when committing.

- [xcp/net/ifrename/{dynamic,static}.py: Fix else-after-continue](https://github.com/xenserver/python-libs/commit/0fc314c6a26f0820a4f10651ade1e73d1dd102b8)
  - Fix pylint's else-after-continue warnings

- [xcp/net/ifrename/{dynamic,static}.py: Use isort to sort imports](https://github.com/xenserver/python-libs/commit/e32c88e595cb2bfb9d802bb763c6a378de93dc2c)
  - Apply isort changes to fix pylint import-order warnings
  - Change relative import to absolute as used for other imports