### PR TITLE
Use local httpserver for tests

### DIFF
--- a/stubs/werkzeug/wrappers.pyi
+++ b/stubs/werkzeug/wrappers.pyi
@@ -1,2 +1,3 @@
-from _typeshed import Incomplete
+from _typeshed import Incomplete  # pylint: disable=import-error,no-name-in-module
+Request = Incomplete
 Response = Incomplete

--- a/tests/httpserver_testcase.py
+++ b/tests/httpserver_testcase.py
@@ -1,0 +1,49 @@
+import os
+import unittest
+from typing import Callable, Optional
+
+import pytest
+
+# Skip the tests in this module if Python <= 3.6 (pytest_httpserver requires Python >= 3.7):
+try:
+    from http.client import HTTPResponse
+
+    from pytest_httpserver import HTTPServer
+    from werkzeug.wrappers import Request, Response
+
+    ErrorHandler = Optional[Callable[[Request], Response]]
+except ImportError:
+    pytest.skip(allow_module_level=True)
+
+
+class HTTPServerTestCase(unittest.TestCase):
+    HTTPResponse = HTTPResponse  # pyright: ignore[reportUnboundVariable]
+    httpserver = HTTPServer()  # pyright: ignore[reportUnboundVariable]
+
+    @classmethod
+    def setUpClass(cls):
+        cls.httpserver.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpserver.check_assertions()
+        cls.httpserver.stop()
+
+    @classmethod
+    def serve_file(cls, root, file_path, error_handler=None, real_path=None):
+        # type:(str, str, Optional[Callable[[Request], Response]], Optional[str]) -> None
+        """Expect a GET request and handle it using the local pytest_httpserver.HTTPServer"""
+
+        def handle_get(request):
+            # type:(Request) -> Response
+            """Handle a GET request for the local pytest_httpserver.HTTPServer fixture"""
+            if error_handler:
+                response = error_handler(request)
+                if response:
+                    return response
+            filepath = root + (real_path or file_path)
+            assert os.path.exists(path=filepath)
+            with open(file=filepath, mode="rb") as local_testdata_file:
+                return Response(local_testdata_file.read())
+
+        cls.httpserver.expect_request(uri="/" + file_path).respond_with_handler(func=handle_get)

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -35,14 +35,6 @@ class TestAccessor(unittest.TestCase):
         self.assertEqual(a.lastError, 404)
         a.finish()
 
-    def test_http_accessor_access(self):
-        """Test HTTPAccessor.access()"""
-
-        # Temporary: To be obsoleted by a dedicated test case using a pytest-native
-        # httpd which will cover code paths like HTTP Basic Auth in an upcoming commit:
-        a = xcp.accessor.createAccessor("https://updates.xcp-ng.org/netinstall/8.2.1", True)
-        self.check_repo_access(a)
-
     def test_filesystem_accessor_access(self):
         """Test FilesystemAccessor.access()"""
 

--- a/tests/test_httprepository.py
+++ b/tests/test_httprepository.py
@@ -1,0 +1,50 @@
+"""Test xcp.repository using a local pure-Python http(s)server fixture"""
+from contextlib import contextmanager
+
+from xcp.accessor import HTTPAccessor, createAccessor
+from xcp.repository import BaseRepository, YumRepository
+from xcp.version import Version
+
+from .httpserver_testcase import HTTPServerTestCase
+
+
+class HTTPRepositoryTestCase(HTTPServerTestCase):
+    document_root = "tests/data/repo/"
+
+    @contextmanager
+    def get_httpaccessor(self, url):
+        """Serve a GET request, assert that the accessor returns the content of the GET Request"""
+        httpaccessor = createAccessor(url, True)
+        assert isinstance(httpaccessor, HTTPAccessor)
+        yield httpaccessor
+        httpaccessor.finish()
+
+    def test_xenserver_yum_repo(self):
+        """Test a combined Yum and XenSource repository"""
+        yum_repo_files = [
+            YumRepository.TREEINFO_FILENAME,
+            YumRepository.REPOMD_FILENAME,
+        ]
+        xensource_repo_files = [
+            "XS-REPOSITORY",
+            "XS-PACKAGES",
+            "XS-REPOSITORY-LIST",
+        ]
+        repofiles = yum_repo_files + xensource_repo_files
+        # sourcery skip: no-loop-in-tests
+        for subdir in ("", ".main", ".linux", ".site"):
+            for file in xensource_repo_files:
+                name = "packages" + subdir + "/" + file
+                repofiles += [name]
+        with self.get_httpaccessor(url=self.httpserver.url_for(suffix="")) as httpaccessor:
+            for path in repofiles:
+                realpath = path.split(sep="/")[1] if path.startswith("packages") else path
+                self.serve_file(
+                    root=self.document_root,
+                    file_path=path,
+                    error_handler=None,
+                    real_path=realpath,
+                )
+            assert BaseRepository.getRepoVer(access=httpaccessor) == Version(ver=[3, 2, 1])
+            assert BaseRepository.getProductVersion(access=httpaccessor) == Version(ver=[8, 2, 1])
+            assert len(BaseRepository.findRepositories(access=httpaccessor)) == 6

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -10,9 +10,6 @@ class TestRepository(unittest.TestCase):
         # Contains an XS-PACKAGES file to cover _create_package() for supp-pack-build
         assert len(self.check_repo_tree("file://tests/data/repo/")) == 2
 
-    def test_http(self):
-        assert len(self.check_repo_tree("https://updates.xcp-ng.org/netinstall/8.2.1")) == 1
-
     def check_repo_tree(self, url):
         a = xcp.accessor.createAccessor(url, True)
         repo_ver = repository.BaseRepository.getRepoVer(a)


### PR DESCRIPTION
## Improvements
* Adds new test cases for `xcp.repository` which covers 4 additional repository code paths not covered before.
* Makes the HTTP tests work independent of https://updates.xcp-ng.org and any changes to it
* Makes it possible to run `pytests tests/` run off-line or with spotty internet connection
* Makes the tests complete in half-time as the overhead of the use https://updates.xcp-ng.org is removed

### Other minor improvements
* The HTTP test base class separates the concerns of HTTP testing in general from specific tests
* Improves type annotations in HTTP tests

## Commits

- [tests/httpserver_testcase.py: Add common base class for HTTP tests](https://github.com/xenserver/python-libs/commit/39f9b752b3dfeb9ce3d0885c4dcf261ce56efe32)

   Add a common base class for HTTP tests using pytest_httpserver:
   - tests/test_httpaccessor.py   (self-contained HTTP test for xcp.accessor)
   - tests/test_httprepository.py (self-contained HTTP test for xcp.repository)

- [tests/test_httpaccessor.py: Use common class HTTPServerTestCase](https://github.com/xenserver/python-libs/commit/51aef734efe57aeaa52b6d08e51c3948bb3b9328)

  Make use of the common class HTTPServerTestCase: Many imports and methods are now provided by `tests/httpserver_testcase.py`

- [tests/test_httprepository.py: Use local YUM and XenSource repos](https://github.com/xenserver/python-libs/commit/3a1dab665603338bc87f09e30a4415f5fcdeb123)

  Add a new self-contained testcase for testing YUM and XenSource repos with: .treeinfo, repomd.xml, packages, packages.main, .linux and .site

  `tests/data/repo` provides all test data, no use of updates.xcp-ng.org, runs offline (no internet connection) and is therefore very fast.

- [tests/test_{accessor,repository}.py: Remove obsoleted HTTP tests](https://github.com/xenserver/python-libs/commit/c300114441911bbffc41a976daf578c699053bcb)

  Remove obsolete HTTP test cases using https://updates.xcp-ng.org/ which are now replaced by new tests in tests/test_http{accessor,repository}.py