### PR TITLE
Minor cosmetics

### DIFF
--- a/stubs/pytest_httpserver.pyi
+++ b/stubs/pytest_httpserver.pyi
@@ -1,19 +1,17 @@
 import abc
-from _typeshed import Incomplete
 from enum import Enum
 from ssl import SSLContext
-from typing import Any, Callable, Iterable, List, Mapping, MutableMapping, Optional, Pattern, Tuple, Union
-from werkzeug.datastructures import MultiDict
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional, Pattern, Tuple, Union
+
+# pylint: disable=import-error, no-name-in-module, super-init-not-called, multiple-statements, too-few-public-methods, invalid-name, line-too-long
+from _typeshed import Incomplete
+
 from werkzeug.wrappers import Request, Response
 
 URI_DEFAULT: str
 METHOD_ALL: str
 HEADERS_T = Union[Mapping[str, Union[str, Iterable[str]]], Iterable[Tuple[str, str]]]
 HVMATCHER_T = Callable[[str, Optional[str], str], bool]
-
-class Undefined: ...
-
-UNDEFINED: Incomplete
 
 class Error(Exception): ...
 class NoHandlerError(Error): ...

--- a/xcp/mount.py
+++ b/xcp/mount.py
@@ -45,7 +45,7 @@ def mount(dev, mountpoint, options = None, fstype = None, label = None):
     if label:
         cmd += ['-L', "%s" % label]
     else:
-        assert(dev)
+        assert dev
         cmd.append(dev)
     cmd.append(mountpoint)
 
@@ -66,8 +66,7 @@ def umount(mountpoint, force = False):
         cmd.append('-f')
     cmd.append(mountpoint)
 
-    rc = xcp.cmd.runCmd(cmd)
-    return rc
+    return xcp.cmd.runCmd(cmd)
 
 class TempMount(object):
     def __init__(self, device, tmp_prefix, options = None, fstype = None,

--- a/xcp/pci.py
+++ b/xcp/pci.py
@@ -82,17 +82,17 @@ class PCI(object):
                 self.segment = 0
 
             self.bus = int(groups["bus"], 16)
-            if not ( 0 <= self.bus < 2**8 ):
+            if not 0 <= self.bus < 2**8:
                 raise ValueError("Bus '%d' out of range 0 <= bus < 256"
                                  % (self.bus,))
 
             self.device = int(groups["device"], 16)
-            if not ( 0 <= self.device < 2**5):
+            if not 0 <= self.device < 2**5:
                 raise ValueError("Device '%d' out of range 0 <= device < 32"
                                  % (self.device,))
 
             self.function = int(groups["function"], 16)
-            if not ( 0 <= self.function < 2**3):
+            if not 0 <= self.function < 2**3:
                 raise ValueError("Function '%d' out of range 0 <= device "
                                  "< 8" % (self.function,))
 

--- a/xcp/version.py
+++ b/xcp/version.py
@@ -78,12 +78,13 @@ class Version(object):
 
     @classmethod
     def arc_cmp(cls, l, r):
+        # type:(int, int) -> int
         return l - r
 
     @classmethod
     def ver_cmp(cls, l, r):
-        assert type(l) is list
-        assert type(r) is list
+        # type:(list[int], list[int]) -> int
+        assert isinstance(l, list) and isinstance(r, list)
 
         # iterate over arcs in turn, zip() returns min(len(l), len(r)) tuples
         for la, ra in zip(l, r):

--- a/xcp/xmlunwrap.py
+++ b/xcp/xmlunwrap.py
@@ -76,7 +76,7 @@ def getBoolAttribute(el, attrs, default = None):
         return default
     return val in ['yes', 'true']
 
-def getIntAttribute(el, attrs, default = None):
+def getIntAttribute(el, attrs, default = None):  # pylint: disable=inconsistent-return-statements
     # type:(Element, list[str], Optional[int]) -> int | None
     mandatory = default is None
     val = getStrAttribute(el, attrs, '', mandatory)


### PR DESCRIPTION
Four minor cosmetic updates:

- [xcp/pci.py: Fix pylint Unnecessary parens after 'not' keyword](https://github.com/xenserver/python-libs/commit/8089b121434573d2d27865c50e190235b131c190)

  - Fix pylint warning superfluous-parens (Unnecessary parens after 'not')

- [xcp/version.py: Add missing type annotations and merge asserts](https://github.com/xenserver/python-libs/commit/0c01be201b5d8e87dddf70b8cac405fd8450ffd5)

- [xcp/xmlunwrap.py: Fix false positive from raise in six.raise_from()](https://github.com/xenserver/python-libs/commit/872472629676b76076421247e0fa5c9735774c6f)

- [stubs/pytest_httpserver.pyi: Silence pylint warnings](https://github.com/xenserver/python-libs/commit/d63fef1f8e8cd0d21add90218b5c30133673d9a4)