### PR TITLE
GitHub CI with tox: Fix Python 2.7 CI to use apt-get install

### DIFF
--- a/.github/act-serial.yaml
+++ b/.github/act-serial.yaml
@@ -45,8 +45,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Python 2.7 using apt-get install
-        if: ${{ matrix.python-version == 3.10 }}
+      - name: Install Python 2.7 from Ubuntu 20.04 using apt-get install
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: apt-get update && apt-get install -y python2-dev
 
       - name: Run of tox on ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,14 +28,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: '3.11'
-          os: ubuntu-22.04
-        # This tests with Python 2.7 and the stock Python 3.10 for combined py2+3 coverage:
-        - python-version: '2.7'
-          os: ubuntu-22.04
-        - python-version: '3.8'
-          os: ubuntu-22.04
         - python-version: '3.6'
+          os: ubuntu-20.04
+        - python-version: '3.10'
+          os: ubuntu-22.04
+        - python-version: '3.11'
           os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
@@ -43,15 +40,17 @@ jobs:
         with:
           fetch-depth: 0  # Needed by diff-cover to get the changed lines: origin/master..HEAD
       - name: Set up Python ${{ matrix.python-version }}
-        # setup-python stopped supporting Python 2.7, use https://github.com/MatteoH2O1999/setup-python
-        # This action tries to build all Python versions that actions/setup-python does not support.
-        # It caches built versions, so that after the first run, installation time is really low.
-        uses: MatteoH2O1999/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          allow-build: info
-          cache-build: true
-          cache: pip
+
+      - name: Install Python 2.7 from Ubuntu 20.04 using apt-get install
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: sudo apt-get update && sudo apt-get install -y python2-dev
+
+      - name: Install missing cpio in containers of nektos/act
+        if: ${{ github.actor == 'nektos/act'}}
+        run: apt-get update && apt-get install -y cpio
 
       - name: Run of tox on ubuntu-latest
         if: ${{ startsWith(matrix.python-version, '3.') && matrix.python-version != 3.6 }}
@@ -61,28 +60,24 @@ jobs:
 
       # tox >= 4.0.0 is needed for using optional-dependencies from pyproject.toml, which is
       # is not available for python <= 3.6, so use the python3.8 of Ubuntu-20.04 to install it:
-      - name: Install of tox on ubuntu-22.04 (to support optional-dependencies from pyproject.toml)
+      - name: Run tox for 3.6 and 3.8 on ${{ matrix.os }}'s 3.8 to get 'extras' from pyproject.toml)
         if: ${{ matrix.python-version == 2.7 || matrix.python-version == 3.6 }}
         run: |
           set -xv;curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-          python3.10 get-pip.py
+          python3.8 get-pip.py
+          # The alternative is installing python3-pip but we don't need full pip function for now:
+          # sudo apt-get update && sudo apt-get install -y python3-pip
+          # Let tox-gh-actions get the environment(s) to run tests with from tox.ini:
           # Use tox==4.5.1: tox>=4 is needed for reading the extras from pyproject.toml
-          # while tox>=4.5.2 depends on virutalenv>=20.23, which breaks Python 2.7:
-          python3.10 -m pip install 'virtualenv<20.22' 'tox==4.5.1' tox-gh-actions
-
-      - name: Run tox4 with Python 3.10(to support optional-dependencies from pyproject.toml) for Python3.6
-        if: ${{ matrix.python-version == 3.6 }}
-        run: tox --workdir .github/workflows/.tox --recreate -e py36-lint
-
-      - name: Generate combined test-coverage with Python 2.7 and 3.10 for Upload
-        if: ${{ matrix.python-version == 2.7 }}
-        run: tox --workdir .github/workflows/.tox --recreate -e py310-covcombine-check
+          # Warning: tox>=4.5.2 depends on virutalenv>=20.23, which breaks Python 2.7:
+          python3.8 -m pip install 'virtualenv<20.22' 'tox==4.5.1' tox-gh-actions
+          tox --workdir .github/workflows/.tox --recreate
 
       - name: Upload coverage reports to Codecov
-        if: ${{ matrix.python-version == 2.7 }}
+        if: ${{ matrix.os == 'ubuntu-20.04' && github.actor != 'nektos/act'}}
         uses: codecov/codecov-action@v3
         with:
-          directory: .github/workflows/.tox/py310-covcombine-check/log
+          directory: .github/workflows/.tox/py38-covcombine-check/log
           env_vars: OS,PYTHON
           fail_ci_if_error: true
           flags: unittest

--- a/tests/test_ifrename_logic.py
+++ b/tests/test_ifrename_logic.py
@@ -1,4 +1,5 @@
 # pyright: reportGeneralTypeIssues=false
+# pytype: disable=attribute-error
 from __future__ import print_function
 from __future__ import unicode_literals
 import logging

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 # 2. python 3.6 test and pylint warnings from changed lines
 # 3. pytype (needs Python 3.8 for best results)
 # 4. pyre and pyright checks, pytest test report as markdown for GitHub Actions summary
-envlist = py310-covcombine-check, py36-lint-test, py38-pytype, py311-pyre-mdreport
+envlist = py38-covcombine-check, py36-lint-test, py310-pytype, py311-pyre-mdreport
 isolated_build = true
 skip_missing_interpreters = true
 requires =
@@ -209,6 +209,7 @@ commands =
 deps = pytype
     pandas
 commands =
-    python3.8 -V # Needs python <= 3.10; but 3.10 has an issue with newer xml.dom.minidom
+    python3.10 -V # Needs python <= 3.10, and 3.10 is needed to parse new "|" syntax
     pytype --version
-    python ./run-pytype.py
+    # Runs pytype -j auto -k --config .github/workflows/pytype.cfg and parses the output:
+    python3 ./run-pytype.py # When switching versions, update .github/workflows/pytype.cfg too!


### PR DESCRIPTION
My 1st try to fix Python 2.7 CI after GitHub dropped it was to use an action wrapping GitHub's setup-python action.

But this stopped working for Python 2.7, so this reverts to GitHub's action again
and uses apt-get install for Python 2.7 on Ubuntu 20.04

It has to rearrange the jobs again among the Ubuntu 20.04 and 22.04 images
to use Ubuntu 20.04 for Python 2.7.

> Next PRs: I have 2 minor PRs for fixing the CI infrastructure to submit after this PR.