### PR TITLE
xcp/bootloader.py: Fix CP-41302 for pre-commit and github CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ inputs = ["xcp", "tests", "./*.py"]
 keepgoing = true
 platform = "linux"
 python_version = "3.10"
+pythonpath = ".:stubs"
 disable = ["ignored-type-comment"]
 overriding_parameter_count_checks = true
 use_enum_overlay = true

--- a/xcp/bootloader.py
+++ b/xcp/bootloader.py
@@ -21,18 +21,22 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
-from __future__ import division
+from __future__ import division, print_function
+
+import copy
 import os
 import os.path
 import re
 import tempfile
-import copy
 from typing import cast
 
-import xcp.branding as branding  # pytype: disable=import-error
-
 import xcp.cmd
+
+# pyre-ignore-all-errors[21]
+try:  # xenserver-release.rpm puts a branding.py into our xcp installation directory:
+    from xcp import branding  # type:ignore[attr-defined] # pytype: disable=import-error
+except ImportError:  # For CI, use stubs/branding.py (./stubs is added to pythonpath)
+    import branding
 
 from .compat import open_textfile
 


### PR DESCRIPTION
Fix CP-41302 for pre-commit and GitHub CI.

Also order the imports: Needed to fix `pylint` checks and `darker`

These fixes also add the needed setting of `pythonpath = ".:stubs"` in the `[tool.pytype]` section of `pyproject.toml` to make `pytype` find the fallback `stubs/branding.py`.

This configuration is also needed to fix that `pytype` can now be run without setting any `PYTHONPATH` (manually and in tools which call it) beforehand.