### PR TITLE
Set MenuEntry extra if it has valid value

### DIFF
--- a/xcp/bootloader.py
+++ b/xcp/bootloader.py
@@ -586,11 +586,7 @@ class Bootloader(object):
                 if text:
                     print("\n".join(text), file=fh)
 
-            extra = ' '
-            try:
-                extra = m.extra
-            except AttributeError:
-                pass
+            extra = m.extra if m.extra else ' '
             print("menuentry '%s'%s{" % (m.title, extra), file=fh)
 
             try:


### PR DESCRIPTION
MenuEntry has `extra` attr defined to `None` in its constructor, Thus always got `extra` attr, and default to `None`. Try to access `extra` attr would never got `AttributeError`, and thus got value default to `None`. However, the expected default value should be ` `

Set extra value by checking whether extra got a valid value