### PR TITLE
CA-389988: Do not consider USB network cards not named ethX

### DIFF
--- a/xcp/net/biosdevname.py
+++ b/xcp/net/biosdevname.py
@@ -75,7 +75,7 @@ def all_devices_all_names():
                 continue
 
             # Treat USB devices the PCI device of their host adapter
-            if dinfo.get("Bus Info", "").startswith("usb-"):
+            if dinfo.get("Bus Info", "").startswith("usb-") and "eth" in dinfo["Kernel name"]:
                 dinfo["Bus Info"] = dinfo["Bus Info"].split('-')[1]
 
             kname = dinfo["Kernel name"]


### PR DESCRIPTION
USB network cards are assigned names using various rules. They can be usbX, ethX, wanX or wwanX based on different features. Our interface rename code bails out if the name is not in ethX format so ignore them.