### PR TITLE
tests/test_ifrename_dynamic: Merge duplicate code into common functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ build-backend = "setuptools.build_meta"
 packages = ["xcp", "xcp.net", "xcp.net.ifrename"]
 
 [tool.black]
-line-length = 96
+line-length = 92
 
 [tool.mypy]
 pretty = true

--- a/tests/test_ifrename_dynamic.py
+++ b/tests/test_ifrename_dynamic.py
@@ -24,12 +24,15 @@ class TestLoadAndParse(unittest.TestCase):
         self.logbuf.close()
 
     def test_null(self):
+        self.assertLoadDynamicRules("")
 
-        fd = StringIO("")
-        dr = DynamicRules(fd=fd)
-
+    def loadDynamicRules(self, rules):
+        dr = DynamicRules(fd=StringIO(rules))
         self.assertTrue(dr.load_and_parse())
+        return dr
 
+    def assertLoadDynamicRules(self, rules):
+        dr = self.loadDynamicRules(rules)
         self.assertEqual(dr.lastboot, [])
         self.assertEqual(dr.old, [])
 
@@ -46,40 +49,21 @@ class TestLoadAndParse(unittest.TestCase):
         self.assertEqual(dr.old, [])
 
     def test_one_invalid(self):
-
-        fd = StringIO(
-            '{"lastboot":[["","",""]],"old":[]}'
-            )
-        dr = DynamicRules(fd=fd)
-
-        self.assertTrue(dr.load_and_parse())
-
-        self.assertEqual(dr.lastboot, [])
-        self.assertEqual(dr.old, [])
+        self.assertLoadDynamicRules('{"lastboot":[["","",""]],"old":[]}')
 
     def test_one_valid_lastboot(self):
-
-        fd = StringIO(
+        dr = self.loadDynamicRules(
             '{"lastboot":[["01:23:45:67:89:0a","00:10.2","eth2"]],"old":[]}'
-            )
-        dr = DynamicRules(fd=fd)
-
-        self.assertTrue(dr.load_and_parse())
-
-        self.assertEqual(dr.lastboot,
-                         [MACPCI("01:23:45:67:89:0a","00:10.2", tname="eth2")])
+        )
+        self.assertEqual(
+            dr.lastboot, [MACPCI("01:23:45:67:89:0a", "00:10.2", tname="eth2")]
+        )
         self.assertEqual(dr.old, [])
 
-
     def test_one_valid_lastboot2(self):
-
-        fd = StringIO(
+        dr = self.loadDynamicRules(
             '{"lastboot":[],"old":[["01:23:45:67:89:0a","00:10.2","eth2"]]}'
-            )
-        dr = DynamicRules(fd=fd)
-
-        self.assertTrue(dr.load_and_parse())
-
+        )
         self.assertEqual(dr.lastboot, [])
         self.assertEqual(dr.old,
                          [MACPCI("01:23:45:67:89:0a","00:10.2", tname="eth2")])


### PR DESCRIPTION
### tests/test_ifrename_dynamic: Merge duplicate code into two small common functions

The duplicated code was detected by a specialized tool, and it prepared merging them for me as well.

I reviewed the work and moved the common functions so that the change is easy to review.
```py
$ git log -n1 -p | diffstat
  pyproject.toml                 |    2 +-
  tests/test_ifrename_dynamic.py |   44 ++++++++++++++------------------------------
  2 files changed, 15 insertions(+), 31 deletions(-)
```
The change to `pyproject.toml` is needed to make the max-columns for `black` less wide:
It stops `black` from create an overlong joined line in the context of the diff.

The plan would be anyways to make the code formatting less wide.
It's a good find that the columns (were 96) was too wide, and this improves it.