### PR TITLE
tox.ini: Create directory for GITHUB_STEP_SUMMARY before writing it

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -149,8 +149,9 @@ commands =
       --markdown-report {envlogdir}/coverage-diff.md                                  \
                         {envlogdir}/coverage.xml;      EXIT_CODE=$?;echo $EXIT_CODE;  \
     GITHUB_STEP_SUMMARY={env:GITHUB_STEP_SUMMARY:.git/GITHUB_STEP_SUMMARY.md};        \
-           if     [ -n "$GITHUB_STEP_SUMMARY" ];  then      sed "/title/,/\/style/d"  \
-                        {envlogdir}/coverage-diff.html  >>"$GITHUB_STEP_SUMMARY"; fi; \
+                            if  [ -n "$GITHUB_STEP_SUMMARY" ]; then                    \
+                            mkdir -p ${GITHUB_STEP_SUMMARY%/*};sed "/title/,/\/style/d"\
+    {envlogdir}/coverage-diff.html >>"$GITHUB_STEP_SUMMARY"; fi;                       \
     exit $EXIT_CODE'
 
 [lint]


### PR DESCRIPTION
### tox.ini: Create directory for GITHUB_STEP_SUMMARY before writing it

Add an `mkdir -p` to create the parent directory for `$GITHUB_STEP_SUMMARY` before writing to it.