### PR TITLE
[Fix CI] Suppress false positive of pyre about nonexisting pytest.raises()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,10 @@ mypy = [
     "types-six",
     "types-toml",
 ]
+# pyre introduced two false-postives recently, pin it to prevent further surprises:
 pyre = [
-    "pyre-check",
-    "pyre-extensions",
+    "pyre-check == 0.9.21",
+    "pyre-extensions == 0.0.30",
 ]
 pytype = [
     "pandas",

--- a/tests/test_cpiofile.py
+++ b/tests/test_cpiofile.py
@@ -1,3 +1,5 @@
+# suppress false positive on pytest missing pytest.raises():
+# pyre-ignore-all-errors[16]
 """
 Test various modes of creating and extracting CpioFile using different compression
 types, opening the archive as stream and as file, using pyfakefs as filesystem without


### PR DESCRIPTION
Two commits for fixing CI:

- `tests/test_cpiofile.py`: [Fix CI] Suppress false positive of pyre about non-existing pytest.raises()
- `pyproject.toml`: pin the current pyre version to prevent more surprises