### PR TITLE
tox.ini: Fix local pre-commit: Add missing space between re and file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -148,10 +148,10 @@ commands =
       --html-report     {envlogdir}/coverage-diff.html                                \
       --markdown-report {envlogdir}/coverage-diff.md                                  \
                         {envlogdir}/coverage.xml;      EXIT_CODE=$?;echo $EXIT_CODE;  \
-    GITHUB_STEP_SUMMARY={env:GITHUB_STEP_SUMMARY:.git/GITHUB_STEP_SUMMARY.md};        \
-                            if  [ -n "$GITHUB_STEP_SUMMARY" ]; then                    \
-                            mkdir -p ${GITHUB_STEP_SUMMARY%/*};sed "/title/,/\/style/d"\
-    {envlogdir}/coverage-diff.html >>"$GITHUB_STEP_SUMMARY"; fi;                       \
+    GITHUB_STEP_SUMMARY={env:GITHUB_STEP_SUMMARY:.git/GITHUB_STEP_SUMMARY.md};          \
+                            if  [ -n "$GITHUB_STEP_SUMMARY" ]; then                     \
+                            mkdir -p ${GITHUB_STEP_SUMMARY%/*};sed "/title/,/\/style/d" \
+    {envlogdir}/coverage-diff.html >>"$GITHUB_STEP_SUMMARY"; fi;                        \
     exit $EXIT_CODE'
 
 [lint]


### PR DESCRIPTION
One commit to fix the local pytest test using pre-commit hook (which then calls tox):

tox.ini: Fix local pre-commit:
- Add missing space between the `sed` expression and the filename