### PR TITLE
.pre-commit-config.yaml: mypy wants types-toml now, add it as dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,7 @@ repos:
         - pytest-subprocess
         - types-mock
         - types-six
+        - types-toml
 
 
 -   repo: https://github.com/rcmdnk/pyproject-pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,10 @@ mypy = [
     "types-six",
     "types-toml",
 ]
+# pyre introduced two false-postives recently, pin it to prevent further surprises:
 pyre = [
-    "pyre-check",
-    "pyre-extensions",
+    "pyre-check == 0.9.21",
+    "pyre-extensions == 0.0.30",
 ]
 pytype = [
     "pandas",

--- a/tests/test_cpiofile.py
+++ b/tests/test_cpiofile.py
@@ -1,3 +1,5 @@
+# suppress false positive on pytest missing pytest.raises():
+# pyre-ignore-all-errors[16]
 """
 Test various modes of creating and extracting CpioFile using different compression
 types, opening the archive as stream and as file, using pyfakefs as filesystem without


### PR DESCRIPTION
Update the config file for the `pre-commit` tool that can be used to run tests and checks locally:

`.pre-commit-config.yaml`: `mypy` wants `types-toml` now, add it as dependency

The other two commits are from #134, which is needed to fix the GitHub Actions CI.