### PR TITLE
cpiofile: Add unittest opening a symlink as fileobj

### DIFF
--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -2,11 +2,14 @@ codecov
 covcombine
 coverallsapp
 cpio
+cpiofile
+cpioinfo
 euxv
 ibft
 ifrename
 kname
 lastboot
+linkname
 logbuf
 MACPCI
 nektos

--- a/xcp/cpiofile.py
+++ b/xcp/cpiofile.py
@@ -1463,7 +1463,7 @@ class CpioFile(six.Iterator):
                 self._dbg(1, "cpiofile: %s" % e)
 
     def extractfile(self, member):
-        # type:(CpioInfo) -> ExFileObject | None
+        # type:(CpioInfo | str | bytes) -> ExFileObject | None
         """Extract a member from the archive as a file object. `member' may be
            a filename or a CpioInfo object. If `member' is a regular file, a
            file-like object is returned. If `member' is a link, a file-like
@@ -1489,11 +1489,8 @@ class CpioFile(six.Iterator):
                 # A small but ugly workaround for the case that someone tries
                 # to extract a symlink as a file-object from a non-seekable
                 # stream of cpio blocks.
-                raise StreamError("cannot extract symlink as file object")
-            else:
-                # A symlink's file object is its target's file object.
-                return self.extractfile(self._getmember(cpioinfo.linkname,
-                                                        cpioinfo))  # type: ignore
+                raise StreamError("Need a seekable stream to open() a symlink target!")
+            return self.extractfile(cpioinfo.linkname)
         else:
             # If there's no data associated with the member (directory, chrdev,
             # blkdev, etc.), return None instead of a file object.


### PR DESCRIPTION
Add two more checks to `tests/test_cpiofile.py`:
#### Test extracting a symlink from a seekable `.cpio` archive to a `fileobj`:
```py
    # Test extracting a symlink to a file object:
    if archive_mode.startswith("|"):  # Non-seekable streams raise StreamError
        with pytest.raises(StreamError):
            archive.extractfile("symlink")
    else:  # Expect a seekable fileobj for this test (not a stream) to work:
        fileobj = archive.extractfile("symlink")
        assert fileobj and fileobj.read() == binary_data
```
#### Run all tests not just using a passed `cpio` `fileobj`, but also an acutal `cpio` `file` archive: 
```py
    for comp in ["cpio", "gz", "bz2", "xz"]:
        for filetype in [":", "|"]:
            if comp == "xz" and filetype == ":":
                continue  # streaming xz is not implemented (supported only as file)
            check_archive_mode(filetype + comp, fs)
            if filetype == "|":
+               check_archive_mode(filetype + comp, fs, filename="archive." + comp)
```



#### Changes to `tests/test_cpiofile.py`

- `Refactor` creating the `cpio` archive for the test into a reusable function
- Improve it to also be able to create an actual `file` besides working with file objects.
- Improve the tests to test both, `cpio` archive file objects and real `cpio` files.
- Cover the changed lines in cpiofile.py which obsolete a blank `# type: ignore` comment

#### Changes to `xcp/cpiofile.py`

- Replace the blank `# type: ignore` comment with an assertion and refactor it to simplify the code
  - Uses the fact that `CpioFile.extract()` accepts the member to extract as string
    - It does not have to be a `member` type:
      - Passing the string simplifies the code and obsoletes the need for the blank `type: ignore`