### PR TITLE
`CI PR #1:` Fix GitHub CI and 'tox' for local CI on Ubuntu 24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: '3.6'
-          os: ubuntu-20.04
         - python-version: '3.10'
           os: ubuntu-22.04
         - python-version: '3.11'

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,10 +8,11 @@
 # These are the most of the needed pytest plugins, unfortunately this list does
 # not support ;python_version<=3.0 or ;python_version>3.0. Therefore, it can
 # only list plugins available for all tested python versions (2.7, 3.6 ... 3.11):
+# pytest-localftpserver is also used, but its installation is not checked
+# to to its installation not being detected on Ubuntu 24.04:
 required_plugins =
     pytest_httpserver
     pytest-forked
-    pytest-localftpserver
     pytest-pythonpath
     pytest-subprocess
     pytest-timeout

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 # 2. python 3.6 test and pylint warnings from changed lines
 # 3. pytype (needs Python 3.8 for best results)
 # 4. pyre and pyright checks, pytest test report as markdown for GitHub Actions summary
-envlist = py38-covcombine-check, py36-lint-test, py310-pytype, py311-pyre-mdreport
+envlist = py38-covcombine-check, py311-lint-test, py310-pytype, py311-pyre-mdreport
 isolated_build = true
 skip_missing_interpreters = true
 requires =
@@ -28,9 +28,9 @@ commands    =
     # https://github.com/actions/toolkit/blob/main/docs/commands.md#problem-matchers
     echo "::add-matcher::.github/workflows/PYTHONWARNINGS-problemMatcher.json"
     pytest --cov -v --new-first -x --show-capture=all -rA
-    sh -c 'ls -l {env:COVERAGE_FILE}'
     sh -c 'if [ -n "{env:PYTEST_MD_REPORT_OUTPUT}" -a -n "{env:GITHUB_STEP_SUMMARY}" ];then    \
-      sed -i "s/tests\(.*py\)/[&](&)/" {env:PYTEST_MD_REPORT_OUTPUT}; sed "/title/,/\/style/d" \
+      mkdir -p $(dirname "{env:GITHUB_STEP_SUMMARY:.git/sum.md}");                             \
+      sed "s/tests\(.*py\)/[&](&)/"                                                            \
       {env:PYTEST_MD_REPORT_OUTPUT} >{env:GITHUB_STEP_SUMMARY:.git/sum.md};fi'
 
 [testenv]
@@ -202,8 +202,6 @@ max-line-length = 129
 
 [pyre]
 commands =
-    pyre: python3.11 --version -V # Needs py311-pyre, does not work with py310-pyre
-    python pyre_runner.py
     -pyright
 
 [pytype]


### PR DESCRIPTION
Topic: Fix GitHub CI
- GitHub dropped support for EOL Python versions in GitHub CI

Contents:
- It has become impractical to use EOL versions like Python 2.7 & 3.6 in CI
- It has become counterproductive (hurts `pyright`) to use pyre CI, disable it for now.
- Move forward to run the unit tests with Python 3.11

A follow-up PR has been created that includes this commit and compensates for the minimal loss in code coverage:
- #144

Note:
If you have review comments, I'd like to apply them using the last PR in this series!