### PR TITLE
CA-407115: Adding logic to handle boot entries without additional arguments

### DIFF
--- a/xcp/bootloader.py
+++ b/xcp/bootloader.py
@@ -345,6 +345,12 @@ class Bootloader(object):
             COUNTER += 1
             return "label%d" % COUNTER
 
+        def parse_boot_entry(line):
+            parts = line.split(None, 2)  # Split into at most 3 parts
+            entry = parts[1] if len(parts) > 1 else ""
+            args = parts[2] if len(parts) > 2 else ""
+            return entry, args
+        
         fh = open_textfile(src_file, "r")
         try:
             for line in fh:
@@ -395,23 +401,18 @@ class Bootloader(object):
                 elif title:
                     if l.startswith("multiboot2"):
                         if "tboot" in l:
-                            tboot, tboot_args = (l.split(None, 1)
-                                                 [1].split(None, 1))
+                            tboot, tboot_args = parse_boot_entry(l)
                         else:
-                            hypervisor, hypervisor_args = (l.split(None, 1)
-                                                           [1].split(None, 1))
+                            hypervisor, hypervisor_args = parse_boot_entry(l)
                     elif l.startswith("module2"):
                         if not hypervisor:
-                            hypervisor, hypervisor_args = (l.split(None, 1)
-                                                           [1].split(None, 1))
+                            hypervisor, hypervisor_args = parse_boot_entry(l)
                         elif kernel:
                             initrd = l.split(None, 1)[1]
                         else:
-                            kernel, kernel_args = (l.split(None, 1)
-                                                   [1].split(None, 1))
+                            kernel, kernel_args = parse_boot_entry(l)
                     elif l.startswith("linux"):
-                        kernel, kernel_args = (l.split(None, 1)
-                                               [1].split(None, 1))
+                        kernel, kernel_args = parse_boot_entry(l)
                     elif l.startswith("initrd"):
                         initrd = l.split(None, 1)[1]
                     elif l.startswith("search --label --set root"):


### PR DESCRIPTION

Function readGrub2 parses the arguments for each entries in grub.cfg, Missing arguments would result in an error in the original code. So added logic to handle the case of an entry with no arguments (e.g. memtest86+x64.efi).