### PR TITLE
tox.ini and pyroject.toml: Cleanup dependencies for outdated python packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,6 @@ dependencies = [
     # Info: xcp imports branding, but branding has no distribution, so we can't list it.
     # A stub for testing is in ./stubs, which we configure to be in PYTHONPATH by pytest.
     "six",
-    "configparser; python_version < '3.0'",
-    "pyliblzma; python_version  < '3.0'"
 ]
 
 [project.optional-dependencies]
@@ -50,10 +48,9 @@ test = [
     "pytest>=7",
     "pytest-cov",
     "pytest-forked",
-    "pytest_httpserver; python_version >= '3.7'",
-    "pytest-localftpserver; python_version >= '3.7'",
-    "pytest-localftpserver==0.5.1; python_version <= '3.6'",
-    "pytest-subprocess; python_version >= '3.6'",
+    "pytest_httpserver",
+    "pytest-localftpserver",
+    "pytest-subprocess",
     "pytest-timeout",
     "typing_extensions"
 ]
@@ -75,16 +72,7 @@ pytype = [
     "pytype",
 ]
 tox = [
-    # The latest versions of tox need 'py>=1.11.0' and this is not stated in the deps of tox-4.5.1.
-    "py>=1.11.0",
-    # Use tox==4.5.1: tox>=4 is needed for reading the extras from pyproject.toml
-    # while tox>=4.5.2 depends on virutalenv>=20.23, which breaks Python 2.7:
-    "tox==4.5.1; python_version >= '3.7'",
-    "tox-gh-actions; python_version >= '3.7'",
-    # virtualenv-20.22 breaks using python2.7 for the `py27` virtualenv with tox and newer
-    # versions even break py36(which is also EOL) because py36 does not support
-    # from __future__ import annotations
-    "virtualenv<20.22",
+    "tox-gh-actions",
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -15,16 +15,7 @@ envlist = py311-covcp-check-mdreport, py312-cov-pytype, py313-cov-lint-pyright
 isolated_build = true
 skip_missing_interpreters = true
 requires =
-    # The latest versions of tox need 'py>=1.11.0' and this is not stated in the deps of tox-4.5.1.
-    py>=1.11.0
-    # Use tox==4.5.1: tox>=4 is needed for reading the extras from pyproject.toml
-    # while tox>=4.5.2 depends on virutalenv>=20.23, which breaks Python 2.7:
-    tox==4.5.1; python_version >= '3.7'
-    tox-gh-actions; python_version >= '3.7'
-    # virtualenv-20.22 breaks using python2.7 for the `py27` virtualenv with tox and newer
-    # versions even break py36(which is also EOL) because py36 does not support
-    # from __future__ import annotations
-    virtualenv<20.22
+    tox-gh-actions
 
 [test]
 description = Run pytest in this environment with --cov for use in other stages


### PR DESCRIPTION
tox.ini and pyroject.toml: Cleanup dependencies for outdated Python packages

This is just a minor cleanup to remove the remnants of Python 2.7 and other
workarounds for meanwhile outdated Python packages that aren't an issue anymore.