### PR TITLE
Fix/cleanup remaining Pytest-6 references for Python 2.7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ way to install up-to-date python tools
 
 ```bash
 python3.11 -m pip install pipx
-pipx install tox; pipx install 'pytest<7';pipx install pylint pyright
+pipx install tox; pipx install pytest;pipx install pylint pyright
 pipx inject pytest pytest-{forked,localftpserver,pythonpath,subprocess,timeout} pyfakefs pytest_httpserver six mock
 pipx inject pylint pyfakefs six mock pytest{,_forked,-localftpserver}
 ```
@@ -215,7 +215,7 @@ yet committed in a Git repository and run only them.
 For nicer diffs of dictionaries, arrays and the like, use `pytest-clarity` or `pytest-icdiff`:
 
 ```py
-pip install "pytest<7" pytest-picked pytest-sugar pytest-clarity # pytest-icdiff
+pip install pytest pytest-picked pytest-sugar pytest-clarity # pytest-icdiff
 ```
 
 To verify or extract the dependencies and extras configured in `pyproject.toml` and `tox.ini`

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,9 @@
 ###############################################################################
 # Configuration file for pytest:
-# Compatibility with pytest 6.x for Python 2.7 has been dropped, needs pytest>7
-#
 # See https://docs.pytest.org for documentation on pytest.
 ###############################################################################
 [pytest]
+minversion = 7.0
 required_plugins =
     pytest_httpserver
     pytest_localftpserver
@@ -26,5 +25,4 @@ log_cli=True
 log_cli_level=INFO
 #
 # Add directory to find the example branding.py (needed by bootloader.py) in ./stubs:
-# (Requires pytest >= 7.0.0):
 pythonpath=stubs


### PR DESCRIPTION
Fix and cleanup remaining references to the obsoleted Pytest 6.x for Python 2.7:

This is a follow-up to #149, merged two weeks ago, for @chunjiez to provide an easier pytest environment supporting current pytest versions.

This PR completes the change from #149 by updating the remaining references in the documentation and updating and cleaning up obsolete references to old pytest versions.