### PR TITLE
CA-375347: Add API to get crash kernel memory by version

### DIFF
--- a/tests/test_dom0.py
+++ b/tests/test_dom0.py
@@ -1,7 +1,7 @@
 import unittest
 from mock import patch, Mock
 
-from xcp.dom0 import default_memory, parse_mem, default_vcpus
+from xcp.dom0 import default_memory, crash_kernel_memory, parse_mem, default_vcpus
 
 
 # pylint: disable=invalid-name
@@ -47,6 +47,29 @@ class TestDom0(unittest.TestCase):
                 expected = dom0_mib * 1024
                 calculated = default_memory(host_gib * 1024 * 1024)
                 self.assertEqual(calculated, expected)
+
+            open_mock.assert_called_with("/etc/xensource-inventory")
+
+    def test_crash_kernel_memory(self):
+        def mock_version(open_mock, version):
+            file_mock = Mock()
+            file_mock.readlines.return_value = iter(["PLATFORM_VERSION='%s'\n" % (version,)])
+            open_mock.return_value.__enter__.return_value = file_mock
+
+        test_values = [
+            ('2.9.0',  192 * 1024),   # Old version
+            ('3.0.49', 192 * 1024),   # Just below 3.0.50
+            ('3.0.50', 256 * 1024),   # Threshold for 256 MiB
+            ('3.4.0',  256 * 1024),   # Between thresholds
+            ('3.99.50', 256 * 1024),  # Below 3.99.90
+            ('3.99.90', 512 * 1024),  # Threshold for 512 MiB
+            ('4.0.0',  512 * 1024),   # Above threshold
+        ]
+
+        with patch("xcp.dom0.open_with_codec_handling") as open_mock:
+            for ver, expected_kib in test_values:
+                mock_version(open_mock, ver)
+                self.assertEqual(crash_kernel_memory(), expected_kib)
 
             open_mock.assert_called_with("/etc/xensource-inventory")
 

--- a/xcp/dom0.py
+++ b/xcp/dom0.py
@@ -73,24 +73,36 @@ def default_memory_for_version(host_mem_kib, platform_version):
     else:
         return default_memory_v3(host_mem_kib)
 
-def default_memory(host_mem_kib):
-    """Return the default for the amount of dom0 memory for the
-    specified amount of host memory for the current platform version"""
+def crash_kernel_memory_for_version(platform_version):
+    """Return the default crash kernel memory size in KiB for the given
+    platform version."""
+    # Need to update this if we change the crash kernel memory in the future version
+    if platform_version >= version.Version([3, 99, 90]):
+        return 512 * 1024
+    if platform_version >= version.Version([3, 0, 50]):
+        return 256 * 1024
+    # Earlier versions are far past EOL, so don't consider them
+    return 192 * 1024
 
-    # read current host version
-    platform_version = None
+def _read_platform_version():
+    """Read PLATFORM_VERSION from /etc/xensource-inventory."""
     with open_with_codec_handling("/etc/xensource-inventory") as f:
         for l in f.readlines():
             line = l.strip()
             if line.startswith('PLATFORM_VERSION='):
-                platform_version = version.Version.from_string(
-                                   line.split('=', 1)[1].strip("'"))
-                break
+                return version.Version.from_string(
+                       line.split('=', 1)[1].strip("'"))
+    raise RuntimeError('Could not find PLATFORM_VERSION from inventory.')
 
-    if not platform_version:
-        raise RuntimeError('Could not find PLATFORM_VERSION from inventory.')
+def default_memory(host_mem_kib):
+    """Return the default for the amount of dom0 memory for the
+    specified amount of host memory for the current platform version"""
+    return default_memory_for_version(host_mem_kib, _read_platform_version())
 
-    return default_memory_for_version(host_mem_kib, platform_version)
+def crash_kernel_memory():
+    """Return the default crash kernel memory size in KiB for the
+    current platform version."""
+    return crash_kernel_memory_for_version(_read_platform_version())
 
 
 _size_and_unit_re = re.compile(r"^(-?\d+)([bkmg]?)$", re.IGNORECASE)


### PR DESCRIPTION
During RPU, XC needs to know the crash kernel memory size change.